### PR TITLE
Better Oembed Handling for paragraphs and wysiwyg

### DIFF
--- a/components/layouts/main-content-layout.tsx
+++ b/components/layouts/main-content-layout.tsx
@@ -1,5 +1,5 @@
 import {useAppContext} from "../../context/state";
-import GetActiveTrail from "@/lib/menu";
+import getActiveTrail from "@/lib/menu";
 import {SideNav} from "@/components/menu/side-nav";
 import {DrupalMenuLinkContent} from "next-drupal";
 
@@ -12,7 +12,7 @@ interface MainLayoutProps {
 export const MainContentLayout = ({fullWidth, ...props}: MainLayoutProps) => {
   const appContext = useAppContext();
 
-  const activeTrail = GetActiveTrail(appContext.menu);
+  const activeTrail = getActiveTrail(appContext.menu);
   let subTree;
 
   const cleanSubMenu = (menu: DrupalMenuLinkContent[], activeTrail: number[]) => {

--- a/components/menu/main-menu.tsx
+++ b/components/menu/main-menu.tsx
@@ -1,19 +1,26 @@
 import {DrupalMenuLinkContent} from "next-drupal";
+import {useEffect, useState} from "react";
 import useDropdownMenu from 'react-accessible-dropdown-menu-hook';
+import {Bars4Icon, ChevronDownIcon, ChevronUpIcon} from "@heroicons/react/20/solid";
 
 import {DrupalLink} from "@/components/simple/link";
 import {useAppContext} from "../../context/state";
-import GetActiveTrail from "@/lib/menu";
-import {useState} from "react";
-import {Bars4Icon, ChevronDownIcon, ChevronUpIcon} from "@heroicons/react/20/solid";
-
+import getActiveTrail from "@/lib/menu";
 
 export const MainMenu = ({...props}) => {
   const appContext = useAppContext();
-  const activeTrail = GetActiveTrail(appContext.menu);
+  const activeTrail = getActiveTrail(appContext.menu);
   const [menuOpen, setMenuOpen] = useState(false)
+  const [menuTree, setMenuTree] = useState(appContext.menu)
 
-  if (typeof appContext.menu === 'undefined') {
+  useEffect(() => {
+    if (menuTree.length === 0) {
+      fetch('/api/menu').then(response => response.json())
+        .then(menuTree => setMenuTree(menuTree))
+    }
+  }, [menuTree]);
+
+  if (menuTree.length === 0) {
     return null;
   }
   return (
@@ -27,9 +34,10 @@ export const MainMenu = ({...props}) => {
 
       </div>
 
-      <ul className={`su-list-unstyled su-bg-[#2e2d29] lg:su-bg-white lg:su-flex ${menuOpen ? 'su-block' : 'su-hidden'} lg:su-block`}>
-        {appContext.menu.map((item, i) => <MenuItem key={item.id}
-                                                    active={activeTrail?.[0] && i === activeTrail[0]} {...item}/>)}
+      <ul
+        className={`su-list-unstyled su-bg-[#2e2d29] lg:su-bg-white lg:su-flex ${menuOpen ? 'su-block' : 'su-hidden'} lg:su-block`}>
+        {menuTree.map((item, i) => <MenuItem key={item.id}
+                                             active={activeTrail?.[0] && i === activeTrail[0]} {...item}/>)}
       </ul>
     </div>
   )
@@ -55,22 +63,22 @@ export const MenuItem = ({title, url, items, active, menuLevel = 0}: MenuItemPro
 
       {(items?.length > 0 && menuLevel < 1) &&
           <>
-              <button {...buttonProps}
-                      className="su-mx-[5px] su-text-white lg:su-text-cardinal-red hover:su-underline hover:su-text-black lg:su-border-l-[1px] lg:su-border-[#766253] su-float-right lg:su-float-none">
+            <button {...buttonProps}
+                    className="su-mx-[5px] su-text-white lg:su-text-cardinal-red hover:su-underline hover:su-text-black lg:su-border-l-[1px] lg:su-border-[#766253] su-float-right lg:su-float-none">
                   <span className="su-sr-only">
                     {isOpen ? 'Close' : 'Open'} &quot;{title}&quot; submenu
                   </span>
 
-                {isOpen ? <ChevronUpIcon aria-hidden={true} height={20}/> :
-                  <ChevronDownIcon aria-hidden={true} height={20}/>}
-              </button>
+              {isOpen ? <ChevronUpIcon aria-hidden={true} height={20}/> :
+                <ChevronDownIcon aria-hidden={true} height={20}/>}
+            </button>
 
-              <ul
-                  className={'su-w-[80%] lg:su-w-auto su-z-10 su-shadow-xl su-absolute su-list-unstyled su-bg-[#2e2d29] lg:su-bg-white ' + (isOpen ? '' : 'su-hidden')}
-                  role="menu"
-              >
-                {items.map((item, i) => <MenuItem key={item.id} {...item} menuLevel={menuLevel + 1}/>)}
-              </ul>
+            <ul
+                className={'su-w-[80%] lg:su-w-auto su-z-10 su-shadow-xl su-absolute su-list-unstyled su-bg-[#2e2d29] lg:su-bg-white ' + (isOpen ? '' : 'su-hidden')}
+                role="menu"
+            >
+              {items.map((item, i) => <MenuItem key={item.id} {...item} menuLevel={menuLevel + 1}/>)}
+            </ul>
           </>
       }
     </li>

--- a/components/nodes/node-stanford-news.tsx
+++ b/components/nodes/node-stanford-news.tsx
@@ -1,7 +1,7 @@
 import {News} from "../../types/drupal";
 import {DrupalImage} from "@/components/simple/image";
 import {Paragraph} from "@/components/paragraphs";
-import {Oembed} from "@/components/simple/oembed";
+import Oembed from "@/components/simple/oembed";
 import {DrupalLink} from "@/components/simple/link";
 import {MainContentLayout} from "@/components/layouts/main-content-layout";
 import {formatDate} from "@/lib/format-date";
@@ -45,8 +45,7 @@ export const NodeStanfordNews = ({node, ...props}: NewsNodeProps) => {
 
         {node?.su_news_banner?.field_media_oembed_video &&
             <Oembed
-                src={node.su_news_banner.field_media_oembed_video}
-                title={node.su_news_banner.name}
+                url={node.su_news_banner.field_media_oembed_video}
             />
         }
 

--- a/components/paragraphs/stanford-card.tsx
+++ b/components/paragraphs/stanford-card.tsx
@@ -1,8 +1,9 @@
 import Image from "next/image";
-import Embed from "react-tiny-oembed";
 
 import {CardParagraph} from "../../types/drupal";
 import {Card} from "@/components/patterns/card";
+import Oembed from "@/components/simple/oembed";
+
 
 interface CardProps {
   paragraph: CardParagraph
@@ -18,8 +19,9 @@ export const StanfordCard = ({paragraph, siblingCount, ...props}: CardProps) => 
   let video = null
   let image = null
 
+
   if (videoUrl) {
-    video = <Embed url={videoUrl}/>
+    video = <Oembed url={videoUrl} className="su-h-full"/>
   } else if (imageUrl) {
     image = <Image
       className="su-object-cover su-object-center"

--- a/components/paragraphs/stanford-media-caption.tsx
+++ b/components/paragraphs/stanford-media-caption.tsx
@@ -1,9 +1,9 @@
-import Embed from "react-tiny-oembed";
 import Image from "next/image";
 
 import {MediaCaptionParagraph} from "../../types/drupal";
 import {DrupalLink} from "@/components/simple/link";
 import formatHtml from "@/lib/format-html";
+import Oembed from "@/components/simple/oembed";
 
 interface StanfordMediaCaptionProps {
   paragraph: MediaCaptionParagraph
@@ -31,7 +31,7 @@ export const StanfordMediaCaption = ({paragraph, siblingCount, ...props}: Stanfo
 
       {videoUrl &&
           <div className="su-overflow-hidden su-aspect-[16/9] su-relative">
-            <Embed url={videoUrl}/>
+            <Oembed url={videoUrl} className="su-h-full"/>
           </div>
       }
 

--- a/components/paragraphs/stanford-wysiwyg.tsx
+++ b/components/paragraphs/stanford-wysiwyg.tsx
@@ -9,7 +9,7 @@ interface StanfordWysiwygProps {
 
 export function StanfordWysiwyg({paragraph, siblingCount, ...props}: StanfordWysiwygProps) {
   return (
-    <div {...props} className={`su-max-w-[980px] su-mx-auto ${props.className ?? ''}`}>
+    <div {...props} className={`su-w-full su-max-w-[980px] su-mx-auto ${props.className ?? ''}`}>
       {formatHtml(paragraph?.su_wysiwyg_text?.processed)}
     </div>
   )

--- a/components/simple/oembed.tsx
+++ b/components/simple/oembed.tsx
@@ -1,6 +1,33 @@
-export const Oembed = ({src, title = null, ...props}) => {
-  const iframeSrc = process.env.NEXT_PUBLIC_DRUPAL_BASE_URL + '/media/oembed?url=' + src;
+import React, {useEffect, useRef, useState} from "react";
+import dynamic from "next/dynamic";
+
+const Embed = dynamic(() => import("react-tiny-oembed"));
+
+import useOnScreen from "@/lib/use-on-screen";
+import {ArrowPathIcon} from "@heroicons/react/20/solid";
+
+const Oembed = ({url, ...props}) => {
+  const elemRef = useRef();
+  const elemRefValue = useOnScreen(elemRef);
+  const [isElemRef, setisElemRef] = useState(false);
+
+  useEffect(() => {
+    if (!isElemRef) setisElemRef(elemRefValue);
+  }, [elemRefValue, isElemRef])
+
   return (
-    <iframe src={iframeSrc} title={title} {...props} />
+    <div ref={elemRef} {...props}>
+      {isElemRef && <Embed url={url} LoadingFallbackElement={<Loading/>}/>}
+    </div>
   )
 }
+
+const Loading = () => {
+  return (
+    <div className="su-h-full su-w-full su-flex su-items-baseline">
+      <ArrowPathIcon className="su-mx-auto su-animate-spin su-self-center" width={30} height={30}/>
+    </div>
+  )
+}
+
+export default Oembed;

--- a/lib/format-html.tsx
+++ b/lib/format-html.tsx
@@ -1,8 +1,8 @@
-import {HTMLReactParserOptions, Element, domToReact, attributesToProps} from "html-react-parser"
-import parse from "html-react-parser"
+import parse, {HTMLReactParserOptions, Element, domToReact, attributesToProps} from "html-react-parser"
 
 import {DrupalLink, DrupalLinkBigButton, DrupalLinkButton, DrupalLinkSecondaryButton} from "@/components/simple/link";
 import {DrupalImage} from "@/components/simple/image";
+import Oembed from "@/components/simple/oembed";
 
 const options: HTMLReactParserOptions = {
   replace: (domNode) => {
@@ -14,8 +14,8 @@ const options: HTMLReactParserOptions = {
       switch (domNode.name) {
         case "a":
           // Error handle for <a> tags without an href.
-          if(!nodeProps.href){
-            nodeProps.href='#';
+          if (!nodeProps.href) {
+            nodeProps.href = '#';
           }
 
           if (nodeProps.className.indexOf('su-button--big') > -1) {
@@ -55,13 +55,14 @@ const options: HTMLReactParserOptions = {
           return <pre {...nodeProps}>{domToReact(domNode.children, options)}</pre>
 
         case 'figure':
-          nodeProps.className += ' su-table';
+          nodeProps.className += ' su-table su-mb-20';
           return (
             <figure {...nodeProps}>{domToReact(domNode.children, options)}</figure>
           )
         case 'figcaption':
           nodeProps.className += ' su-table-caption su-text-center';
-          return <figcaption {...nodeProps} style={{captionSide: 'bottom'}}>{domToReact(domNode.children, options)}</figcaption>
+          return <figcaption {...nodeProps}
+                             style={{captionSide: 'bottom'}}>{domToReact(domNode.children, options)}</figcaption>
 
         case 'p':
           nodeProps.className += ' su-max-w-[100ch]';
@@ -115,6 +116,19 @@ const cleanMediaMarkup = (node: Element) => {
   const wrapperDiv = node.children.find(child => child instanceof Element && child.name === 'div')
   const picture = wrapperDiv instanceof Element && wrapperDiv.children.find(child => child instanceof Element && child.name === 'picture')
   let image = wrapperDiv instanceof Element && wrapperDiv.children.find(child => child instanceof Element && child.name === 'img')
+
+  // Special handling of video media type.
+  if (node.attribs.class.indexOf('media--type-video') >= 0) {
+    const iframe = wrapperDiv instanceof Element && wrapperDiv.children.find(child => child instanceof Element && child.name === 'iframe')
+    let {src: iframeSrc} = iframe instanceof Element && iframe.attribs;
+
+    iframeSrc = decodeURIComponent(iframeSrc).replace(/^.*url=(.*)?&.*$/, '$1');
+    return (
+      <div className="su-clear-both su-overflow-hidden su-aspect-[16/9] su-relative">
+        <Oembed className="su-h-full su-w-full" url={iframeSrc}/>
+      </div>
+    );
+  }
 
   if (picture instanceof Element) {
     image = picture.children.find(child => child instanceof Element && child.name === 'img')

--- a/lib/format-html.tsx
+++ b/lib/format-html.tsx
@@ -63,6 +63,9 @@ const options: HTMLReactParserOptions = {
           nodeProps.className += ' su-table-caption su-text-center';
           return <figcaption {...nodeProps}
                              style={{captionSide: 'bottom'}}>{domToReact(domNode.children, options)}</figcaption>
+        case 'iframe':
+          nodeProps.className += ' su-w-full';
+          return <iframe {...nodeProps}/>
 
         case 'p':
           nodeProps.className += ' su-max-w-[100ch]';
@@ -100,6 +103,7 @@ const fixClasses = (classes) => {
     .replace(' su-related-text ', ' su-shadow-lg su-p-30 ')
     .replace(' su-subheading ', ' su-text-[25px] ')
     .replace(' su-callout-text ', ' su-font-bold ')
+    .replace(' visually-hidden ', ' su-sr-only ')
     .replace(/ plain-text | caption /g, ' ')
     .replace(/tablesaw.*? /g, ' ')
     .replace(/ +/g, ' ')

--- a/lib/menu.tsx
+++ b/lib/menu.tsx
@@ -1,6 +1,7 @@
 import {useRouter} from "next/router";
 
-const GetActiveTrail = (menuItems, trail = []) => {
+const getActiveTrail = (menuItems, trail = []) => {
+
   const router = useRouter()
   const currentPath = router.asPath;
 
@@ -14,7 +15,7 @@ const GetActiveTrail = (menuItems, trail = []) => {
     }
 
     if (typeof menuItems[i].items === 'object') {
-      childTrail = GetActiveTrail(menuItems[i].items, [...currentTrail]);
+      childTrail = getActiveTrail(menuItems[i].items, [...currentTrail]);
       if (childTrail.length > 0) {
         return childTrail;
       }
@@ -25,4 +26,4 @@ const GetActiveTrail = (menuItems, trail = []) => {
 
 }
 
-export default GetActiveTrail;
+export default getActiveTrail;

--- a/lib/use-on-screen.tsx
+++ b/lib/use-on-screen.tsx
@@ -1,0 +1,16 @@
+import {useState, useEffect} from "react";
+
+const useOnScreen = (ref) => {
+  const [isIntersecting, setIntersecting] = useState(false);
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => setIntersecting(entry.isIntersecting)
+    );
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+  }, [ref])
+  return isIntersecting;
+}
+
+export default useOnScreen

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,12 +1,19 @@
 import {PageLayout} from "@/components/layouts/page-layout";
+import {DrupalMenuLinkContent} from "next-drupal";
 
-export default function Custom404({...props}) {
+interface Custom404Props {
+
+}
+
+const Custom404 = ({...props}: Custom404Props) => {
   return (
     <PageLayout {...props}>
-      <div className="su-cc">
+      <div id="main-content" className="su-cc">
         <h1>404</h1>
         <p>Page not found</p>
       </div>
     </PageLayout>
   )
 }
+
+export default Custom404;

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import {GetStaticPathsResult, GetStaticPropsResult} from "next"
+import {GetStaticPaths, GetStaticPathsResult, GetStaticProps, GetStaticPropsResult} from "next"
 import {DrupalJsonApiParams} from "drupal-jsonapi-params";
 import {
-  DrupalNode,
+  DrupalMenuLinkContent,
+  DrupalNode, getMenu,
   getPathsFromContext,
   getResourceFromContext,
   translatePathFromContext
@@ -11,24 +11,25 @@ import {
 import {populateParagraphData} from "@/lib/fetch-paragraphs";
 import {PageLayout} from "@/components/layouts/page-layout";
 import {NodePageDisplay} from "@/nodes/index";
-import {cleanNode} from "@/lib/clean-node";
+import {AppWrapper} from "../context/state";
 
 interface NodePageProps {
   node: DrupalNode
+  menuTree: DrupalMenuLinkContent[]
 }
 
-export default function NodePage({node, ...props}: NodePageProps) {
+export default function NodePage({node, menuTree, ...props}: NodePageProps) {
   if (!node) return null
   return (
-    <>
+    <AppWrapper menu={menuTree}>
       <PageLayout {...props}>
         <NodePageDisplay node={node}/>
       </PageLayout>
-    </>
+    </AppWrapper>
   )
 }
 
-export async function getStaticPaths(context): Promise<GetStaticPathsResult> {
+export const getStaticPaths: GetStaticPaths = async (context): Promise<GetStaticPathsResult> => {
   const params = new DrupalJsonApiParams();
   let fetchMore = true;
   let page = 0;
@@ -61,7 +62,7 @@ export async function getStaticPaths(context): Promise<GetStaticPathsResult> {
   }
 }
 
-export async function getStaticProps(context): Promise<GetStaticPropsResult<NodePageProps>> {
+export const getStaticProps: GetStaticProps<{ node: DrupalNode }> = async (context): Promise<GetStaticPropsResult<NodePageProps>> => {
 
   const path = await translatePathFromContext(context);
 
@@ -103,10 +104,11 @@ export async function getStaticProps(context): Promise<GetStaticPropsResult<Node
     }
   }
 
-  cleanNode(node);
+  const {tree} = await getMenu('main');
   return {
     props: {
-      node
+      node,
+      menuTree: tree
     },
     revalidate: 60 * 60
   }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,8 @@
-import App, {AppProps} from "next/app"
-import {DrupalMenuLinkContent, getMenu} from "next-drupal";
+import {AppProps} from "next/app"
 import Router from "next/router"
 import {syncDrupalPreviewRoutes} from "next-drupal"
 import {DefaultSeo} from "next-seo";
 
-import {AppWrapper} from "../context/state";
 import "styles/globals.css"
 import SEO from '../next-seo.config';
 
@@ -12,48 +10,13 @@ Router.events.on("routeChangeStart", path => {
   syncDrupalPreviewRoutes(path)
 })
 
-interface PageProps {
-  menu: DrupalMenuLinkContent[]
-}
-
-interface DrupalAppProps extends AppProps {
-  pageProps: PageProps
-}
-
-function DrupalApp({Component, pageProps}: DrupalAppProps) {
-
+function DrupalApp({Component, pageProps}: AppProps) {
   return (
-    <AppWrapper menu={pageProps.menu}>
+    <>
       <DefaultSeo {...SEO} />
       <Component {...pageProps} />
-    </AppWrapper>
+    </>
   )
 }
 
-DrupalApp.getInitialProps = async (appContext) => {
-  const appProps = await App.getInitialProps(appContext);
-  const {tree} = await getMenu('main');
-
-  const cleanMenuItems = (menu: DrupalMenuLinkContent[]) => {
-    menu.map((menuItem, i) => {
-      if (!menuItem.enabled) {
-        delete menu[i];
-        return;
-      }
-
-      delete menuItem.enabled;
-      delete menuItem.meta;
-      delete menuItem.route;
-      delete menuItem.menu_name;
-      delete menuItem.weight;
-      delete menuItem.provider;
-      delete menuItem.parent;
-      delete menuItem.type;
-      cleanMenuItems(menuItem.items ?? []);
-    })
-  }
-  cleanMenuItems(tree);
-  appProps.pageProps.menu = tree;
-  return {...appProps}
-}
 export default DrupalApp;

--- a/pages/api/menu.tsx
+++ b/pages/api/menu.tsx
@@ -1,0 +1,6 @@
+import {getMenu} from "next-drupal";
+
+export default async function handler(req, res) {
+  const {tree} = await getMenu('main')
+  res.status(200).json(tree);
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,36 +1,40 @@
-import {GetStaticPropsResult} from "next"
-import {DrupalNode, getResource} from "next-drupal"
+import {GetStaticProps, GetStaticPropsResult} from "next"
+import {DrupalMenuLinkContent, DrupalNode, getMenu, getResource} from "next-drupal"
 
 import {NodeStanfordPage} from "@/components/nodes/node-stanford-page";
 import {PageLayout} from "@/components/layouts/page-layout"
 import {populateParagraphData} from "@/lib/fetch-paragraphs";
-import {cleanNode} from "@/lib/clean-node";
+
+import {BasicPage} from "../types/drupal";
+import {AppWrapper} from "../context/state";
 
 interface HomePageProps {
   node: DrupalNode
+  menuTree: DrupalMenuLinkContent[]
 }
 
-const HomePage = ({node, ...props}: HomePageProps) => {
+const HomePage = ({node, menuTree, ...props}: HomePageProps) => {
   return (
-    <>
+    <AppWrapper menu={menuTree}>
       <PageLayout {...props}>
         <h1 className="su-hidden">{process.env.NEXT_PUBLIC_SITE_NAME}</h1>
         <NodeStanfordPage node={node} homepage/>
       </PageLayout>
-    </>
+    </AppWrapper>
   )
 }
 
 export default HomePage;
 
-export async function getStaticProps(): Promise<GetStaticPropsResult<HomePageProps>> {
+export const getStaticProps: GetStaticProps<{ node: BasicPage }> = async (): Promise<GetStaticPropsResult<HomePageProps>> => {
   const node = await getResource<DrupalNode>('node--stanford_page', process.env.DRUPAL_FRONT_PAGE)
   await populateParagraphData(node);
-  cleanNode(node);
+  const {tree} = await getMenu('main');
 
   return {
     props: {
-      node
+      node,
+      menuTree: tree
     },
     revalidate: 60
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,8 +3,14 @@
 @tailwind utilities;
 
 /* Styles for react-tiny-oembed containers */
-.__embed_column {
+.su-aspect-\[16\/9\] .__embed_column {
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.su-aspect-\[16\/9\] .__embed_column iframe {
   width: 100%;
   height: 100%;
-  display:block;
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- refactored the way to fetch the main menu items.
- Adjusted the oembed display to only load when the content is in view
- Fixed the embeddable content in the wysiwyg
- Fixed embedded image in wysiwyg with captions
- Provided a new hook `useOnScreen` to make in view visible elements easier to build

# Steps to Test

1. view the preview build pages:
   - https://deploy-preview-23--stanford-library.netlify.app/test-content/test-text-area-content/test-embeddable-content
      - https://library-dev.sites-pro.stanford.edu/node/106/edit
   - https://deploy-preview-23--stanford-library.netlify.app/test-content/test-text-area-content
      - https://library-dev.sites-pro.stanford.edu/node/81/edit
2. Verify they look as expected compared to the BE side
