### PR TITLE
SUL23-39 | @jdwjdwjdw | Build "Event Series" content display

### DIFF
--- a/src/components/nodes/node-stanford-event-series.tsx
+++ b/src/components/nodes/node-stanford-event-series.tsx
@@ -34,7 +34,7 @@ export const NodeStanfordEventSeries = ({node, ...props}: EventSeriesNodeProps) 
         <Conditional showWhen={node.su_event_series_event}>
           <div className={"md:su-cc su-rs-my-6 su-grid su-gap-xl"}>
             {node.su_event_series_event.map(item =>
-              <div className={"su-pb-50 su-mb-50 last:su-pb-0 su-border-[#c6c6c6] last:su-border-none su-border-b"}>
+              <div key={item.id} className={"su-pb-50 su-mb-50 last:su-pb-0 su-border-[#c6c6c6] last:su-border-none su-border-b"}>
                 <NodeListDisplay node={item} key={item.id}/>
               </div>
             )}

--- a/src/components/nodes/node-stanford-event-series.tsx
+++ b/src/components/nodes/node-stanford-event-series.tsx
@@ -1,6 +1,5 @@
 import {EventSeries} from "../../types/drupal";
 import {Paragraph} from "@/components/paragraphs";
-import {DrupalLink} from "@/components/simple/link";
 import Link from "next/link";
 import {MainContentLayout} from "@/components/layouts/main-content-layout";
 import {NodeListDisplay} from "@/nodes/index";
@@ -15,37 +14,44 @@ export const NodeStanfordEventSeries = ({node, ...props}: EventSeriesNodeProps) 
   return (
     <MainContentLayout pageTitle={node.title}>
       <article {...props}>
-        <div>
-          {node.su_event_series_subheadline}
-        </div>
-        <div>
-          {node.su_event_series_dek}
-        </div>
-        <div>
-          {node.su_event_series_components && node.su_event_series_components.map(paragraph =>
-            <Paragraph key={paragraph.id} paragraph={paragraph}/>
-          )}
-        </div>
-        {node.su_event_series_event && 
-          <div className={"su-my-40 su-grid su-gap-xl"}>
-            {node.su_event_series_event.map(item =>
-            <div className={"su-pb-50 su-mb-50 last:su-pb-0 su-border-[#c6c6c6] last:su-border-none su-border-b"}>
-              <NodeListDisplay node={item} key={item.id}/>
-            </div>
+        <Conditional showWhen={node.su_event_series_subheadline}>
+          <h2 className="su-type-3 su-rs-mb-1">
+            {node.su_event_series_subheadline}
+          </h2>
+        </Conditional>
+        <Conditional showWhen={node.su_event_series_dek}>
+          <div className="su-rs-mb-4 su-text-16 md:su-text-21">
+            {node.su_event_series_dek}
+          </div>
+        </Conditional>
+        <Conditional showWhen={node.su_event_series_components}>
+          <div>
+            {node.su_event_series_components.map(paragraph =>
+              <Paragraph key={paragraph.id} paragraph={paragraph}/>
             )}
           </div>
-        }
+        </Conditional>
+        <Conditional showWhen={node.su_event_series_event}>
+          <div className={"md:su-cc su-rs-my-6 su-grid su-gap-xl"}>
+            {node.su_event_series_event.map(item =>
+              <div className={"su-pb-50 su-mb-50 last:su-pb-0 su-border-[#c6c6c6] last:su-border-none su-border-b"}>
+                <NodeListDisplay node={item} key={item.id}/>
+              </div>
+            )}
+          </div>
+        </Conditional>
       </article>
     </MainContentLayout>
   )
 }
 
 export const NodeStanfordEventSeriesListItem = ({node, ...props}: EventSeriesNodeProps) => {
+  // Not being utilized anywhere currently
   return (
     <article {...props}>
-      <DrupalLink href={node.path.alias}>
+      <Link href={node.path.alias}>
         <h2 className="su-text-cardinal-red">{node.title}</h2>
-      </DrupalLink>
+      </Link>
     </article>
   )
 }

--- a/src/components/nodes/node-stanford-event-series.tsx
+++ b/src/components/nodes/node-stanford-event-series.tsx
@@ -1,8 +1,11 @@
 import {EventSeries} from "../../types/drupal";
 import {Paragraph} from "@/components/paragraphs";
 import {DrupalLink} from "@/components/simple/link";
+import Link from "next/link";
 import {MainContentLayout} from "@/components/layouts/main-content-layout";
 import {NodeListDisplay} from "@/nodes/index";
+import {Card} from "@/components/patterns/card";
+import Conditional from "@/components/simple/conditional";
 
 interface EventSeriesNodeProps {
   node: EventSeries
@@ -49,11 +52,21 @@ export const NodeStanfordEventSeriesListItem = ({node, ...props}: EventSeriesNod
 
 export const NodeStanfordEventSeriesCard = ({node, ...props}: EventSeriesNodeProps) => {
   return (
-    <article className="su-shadow-lg" {...props}>
-      <DrupalLink href={node.path.alias}
-                  className="su-no-underline su-text-cardinal-red hover:su-underline hover:su-text-black">
-        <h2 className="su-text-cardinal-red">{node.title}</h2>
-      </DrupalLink>
+    <article {...props}>
+      <Card
+        header={
+          <Link className="su-text-black hocus:su-underline hocus:su-text-digital-red" href={node.path.alias}>
+            {node.title}
+          </Link>
+        }
+        footer={
+          <Conditional showWhen={node.su_event_series_subheadline}>
+              <span className="su-text-black">
+                {node.su_event_series_subheadline}
+              </span>
+          </Conditional>
+        }
+      />
     </article>
   )
 }

--- a/src/components/nodes/node-stanford-event-series.tsx
+++ b/src/components/nodes/node-stanford-event-series.tsx
@@ -2,6 +2,7 @@ import {EventSeries} from "../../types/drupal";
 import {Paragraph} from "@/components/paragraphs";
 import {DrupalLink} from "@/components/simple/link";
 import {MainContentLayout} from "@/components/layouts/main-content-layout";
+import {NodeListDisplay} from "@/nodes/index";
 
 interface EventSeriesNodeProps {
   node: EventSeries
@@ -9,14 +10,28 @@ interface EventSeriesNodeProps {
 
 export const NodeStanfordEventSeries = ({node, ...props}: EventSeriesNodeProps) => {
   return (
-    <MainContentLayout>
+    <MainContentLayout pageTitle={node.title}>
       <article {...props}>
-        <h1>{node.title}</h1>
-        {node.su_event_series_subheadline}
-        {node.su_event_series_dek}
-        {node.su_event_series_components && node.su_event_series_components.map(paragraph =>
-          <Paragraph key={paragraph.id} paragraph={paragraph}/>
-        )}
+        <div>
+          {node.su_event_series_subheadline}
+        </div>
+        <div>
+          {node.su_event_series_dek}
+        </div>
+        <div>
+          {node.su_event_series_components && node.su_event_series_components.map(paragraph =>
+            <Paragraph key={paragraph.id} paragraph={paragraph}/>
+          )}
+        </div>
+        {node.su_event_series_event && 
+          <div className={"su-my-40 su-grid su-gap-xl"}>
+            {node.su_event_series_event.map(item =>
+            <div className={"su-pb-50 su-mb-50 last:su-pb-0 su-border-[#c6c6c6] last:su-border-none su-border-b"}>
+              <NodeListDisplay node={item} key={item.id}/>
+            </div>
+            )}
+          </div>
+        }
       </article>
     </MainContentLayout>
   )


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [SUL23-39](https://stanfordits.atlassian.net/browse/SUL23-39): Build "Event Series" content display in NextJS

# Review By (Date)
- When does this need to be reviewed by?

# Urgency
- How critical is this PR?

# Steps to Test

1. Checkout branch
2. Create a few example events
3. Create an example Event Series featuring your example events.
4. Compare with [D9](https://userguidetest20210222.sites.stanford.edu/event/series/sws-test-1126-event-series).
5. You can see the event series card by selecting it using the teaser paragraph, or adding a "shared tags" card list. See the bottom of [this page](https://userguidetest20210222.sites.stanford.edu/sws-test-1118-events-lists) for how it appears in D9.
6. It doesn't appear the `NodeStanfordEventSeriesListItem` is be used, so I didn't build that out.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)


<a href="https://gitpod.io/#https://github.com/SU-SWS/sulgryphon-nextjs/pull/39"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

