### PR TITLE
SUL-000 | @jdwjdwjdw | Fix up homepage banner select width and text being cut off

### DIFF
--- a/src/components/nodes/node-stanford-page.tsx
+++ b/src/components/nodes/node-stanford-page.tsx
@@ -212,32 +212,33 @@ const TodayHours = (props) => {
         image={image}
         header="Today&apos;s Hours"
         footer={
-          <>
-            <label htmlFor="library-hours" className="su-sr-only">Choose a library</label>
-            <select
-              id="library-hours"
-              className="su-w-full su-text-black su-text-20 su-py-20 su-mb-20 su-rounded su-shadow"
-              onChange={e => setSelectedLibrary(e.target.value)}
-            >
-              {Object.keys(libraries).map(index =>
-                <option key={index} value={libraries[index].id}>{libraries[index].title}</option>
-              )}
-            </select>
+          <div className="su-relative su-pb-100 md:su-rs-pb-6">
+            <div className="su-absolute">
+              <label htmlFor="library-hours" className="su-sr-only">Choose a library</label>
+              <select
+                id="library-hours"
+                className="su-w-full su-leading-display su-text-black su-text-20 su-py-20 su-mb-20 su-rounded su-shadow"
+                onChange={e => setSelectedLibrary(e.target.value)}
+              >
+                {Object.keys(libraries).map(index =>
+                  <option key={index} value={libraries[index].id}>{libraries[index].title}</option>
+                )}
+              </select>
 
-            <div className="su-text-black su-flex su-justify-between" aria-live="polite">
-
-              <div><ClockIcon className="su-inline" width={15}/> {isOpen ? 'Open' : 'Closed'}</div>
-              <div>
-                {!closedAllDay && (isOpen ? 'Closes at ' + closeTime.toLocaleTimeString("en-US", {
-                  hour: "numeric",
-                  minute: "numeric",
-                }) : 'Opens at ' + openTime.toLocaleTimeString("en-US", {
-                  hour: "numeric",
-                  minute: "numeric",
-                }))}
+              <div className="su-text-black su-flex su-justify-between" aria-live="polite">
+                <div><ClockIcon className="su-inline" width={15}/> {isOpen ? 'Open' : 'Closed'}</div>
+                <div>
+                  {!closedAllDay && (isOpen ? 'Closes at ' + closeTime.toLocaleTimeString("en-US", {
+                    hour: "numeric",
+                    minute: "numeric",
+                  }) : 'Opens at ' + openTime.toLocaleTimeString("en-US", {
+                    hour: "numeric",
+                    minute: "numeric",
+                  }))}
+                </div>
               </div>
             </div>
-          </>
+          </div>
         }
       />
     </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix line height issue with text being cut off in the select by adding `su-leading-display`
- Fix issue where card width was changing based on the text length of the library branch options
![Screen Shot 2023-01-19 at 5 37 19 PM](https://user-images.githubusercontent.com/49299083/213599465-4db19c7e-5ab5-465d-a58c-46cfa719ba16.png)

# Review By (Date)
- When convenient

# Steps to Test

1. Checkout branch or view preview at https://deploy-preview-46--stanford-library.netlify.app/
2. Confirm that select text is no longer cut off, and card width looks good.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
