### PR TITLE
SUL23-42 | @jdwjdwjdw | Build Publication content display in NextJS

### DIFF
--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -20,7 +20,7 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 
   return (
     <MainContentLayout pageTitle={node.title}>
-      {/* {console.log('node', node)} */}
+      {console.log('node', node)}
       <article {...props}>
         <Conditional showWhen={node.su_publication_citation.citation_type}>
           <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
@@ -41,10 +41,10 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
             <div className="lg:su-rs-pl-3 lg:su-border-l su-border-black-10">
               <Conditional showWhen={node.su_publication_citation.su_author.length > 0}>
                 <div className="su-rs-mb-2">
-                    <h2 className="su-text-16 md:su-text-18 2xl:su-text-19">Author(s)</h2>
+                    <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Author(s)</h2>
                     <div>
                       {node.su_publication_citation.su_author && node.su_publication_citation.su_author.map((author, index) =>
-                        <div key={`citation-author-${index}`}>
+                        <div key={`citation-author-${index}` } className="su-text-16 md:su-text-18 2xl:su-text-19">
                           {author.given} {author.family}
                         </div>
                       )}
@@ -54,16 +54,29 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 
               <Conditional showWhen={node.su_publication_citation.su_publisher}>
                 <div className="su-rs-mb-2">
-                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19">Publisher</h2>
-                  {node.su_publication_citation.su_publisher}
+                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Publisher</h2>
+                  <div className="su-text-16 md:su-text-18 2xl:su-text-19">
+                    {node.su_publication_citation.su_publisher}
+                  </div>
+                </div>
+              </Conditional>
+
+              <Conditional showWhen={node.su_publication_citation.su_journal_publisher}>
+                <div className="su-rs-mb-2">
+                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Journal Name</h2>
+                  <div className="su-text-16 md:su-text-18 2xl:su-text-19">
+                    {node.su_publication_citation.su_journal_publisher}
+                  </div>
                 </div>
               </Conditional>
 
               <Conditional showWhen={node.su_publication_citation.su_year}>
-                <div className="su-rs-mb-4">
-                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19">Publication Date</h2>
+                <div className="su-rs-mb-2">
+                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Publication Date</h2>
                   <Conditional showWhen={node.su_publication_citation.su_month && node.su_publication_citation.su_day}>
-                    {getMonthName(node.su_publication_citation.su_month)} {node.su_publication_citation.su_day}, {node.su_publication_citation.su_year}
+                    <div className="su-text-16 md:su-text-18 2xl:su-text-19">
+                      {getMonthName(node.su_publication_citation.su_month)} {node.su_publication_citation.su_day}, {node.su_publication_citation.su_year}
+                    </div>
                   </Conditional>
                   <Conditional showWhen={node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
                     {node.su_publication_citation.su_month}, {node.su_publication_citation.su_year}
@@ -73,10 +86,28 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
                   </Conditional>
                 </div>
               </Conditional>
+              
+              <Conditional showWhen={node.su_publication_citation.su_genre}>
+                <div className="su-rs-mb-2">
+                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Type of Dissertation</h2>
+                  <div className="su-text-16 md:su-text-18 2xl:su-text-19">
+                    {node.su_publication_citation.su_genre}
+                  </div>
+                </div>
+              </Conditional>
+
+              <Conditional showWhen={node.su_publication_citation.su_doi}>
+                <div className="su-rs-mb-2">
+                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">DOI</h2>
+                  <div className="su-text-16 md:su-text-18 2xl:su-text-19">
+                    {node.su_publication_citation.su_doi}
+                  </div>
+                </div>
+              </Conditional>
             </div>
 
             {node.su_publication_cta &&
-              <div className="lg:su-rs-pl-3">
+              <div className="lg:su-rs-pl-3 su-rs-pt-2">
                 <DrupalLinkButton href={node.su_publication_cta.url}>{node.su_publication_cta.title}</DrupalLinkButton>
               </div>            
             }

--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -1,26 +1,94 @@
 import {DrupalPublicationCitation, Publication} from "../../types/drupal";
 import Link from "next/link";
+import {DrupalLinkButton} from "@/components/simple/link";
 import {Rows} from "@/components/paragraphs/row";
 import {MainContentLayout} from "@/components/layouts/main-content-layout";
+import Conditional from "../simple/conditional";
 
 interface PublicationNodeProps {
   node: Publication
 }
 
 export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) => {
+
+  const getMonthName = monthNumber => {
+    const date = new Date();
+    date.setMonth(monthNumber - 1);
+  
+    return date.toLocaleString('en-US', { month: 'long' });
+  };
+
   return (
-    <MainContentLayout>
+    <MainContentLayout pageTitle={node.title}>
+      {console.log('node', node)}
       <article {...props}>
+      {node.su_publication_topics && node.su_publication_topics.map(term=>
+        <div key={term.id} className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">{term.name}</div>
+      )}
+      <div className="md:su-grid su-grid-cols-6 su-gap-[40px]">
+          <div className="su-col-span-4">
+            <div className="su-rs-mb-7 md:su-w-11/12 ">
+
+              {node.su_publication_components && <Rows rows={node.su_publication_components} rowField="su_pubs_components"/>}
+            </div>
+          </div>
+
+          <div className="su-col-span-2">
+            <div className="su-rs-pl-3 su-border-l su-border-black-10">
+              <Conditional showWhen={node.su_publication_citation.su_author.length > 0}>
+                <div className="su-rs-mb-2">
+                    <h2 className="su-type-0">Author(s)</h2>
+                    <div>
+                      {node.su_publication_citation.su_author && node.su_publication_citation.su_author.map((author, index) =>
+                        <div key={`citation-author-${index}`}>
+                          {author.given} {author.family}
+                        </div>
+                      )}
+                    </div>
+                </div>
+              </Conditional>
+
+              <Conditional showWhen={node.su_publication_citation.su_publisher}>
+                <div className="su-rs-mb-2">
+                  <h2 className="su-type-0">Publisher</h2>
+                  {node.su_publication_citation.su_publisher}
+                </div>
+              </Conditional>
+
+              <Conditional showWhen={node.su_publication_citation.su_year}>
+                <div className="su-rs-mb-4">
+                  <h2 className="su-type-0">Publication Date</h2>
+                  <Conditional showWhen={node.su_publication_citation.su_month && node.su_publication_citation.su_day}>
+                    {getMonthName(node.su_publication_citation.su_month)} {node.su_publication_citation.su_day}, {node.su_publication_citation.su_year}
+                  </Conditional>
+                  <Conditional showWhen={node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
+                    {node.su_publication_citation.su_month}, {node.su_publication_citation.su_year}
+                  </Conditional>
+                  <Conditional showWhen={!node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
+                    {node.su_publication_citation.su_year}
+                  </Conditional>
+                </div>
+              </Conditional>
+            </div>
+
+            <Conditional showWhen={node.su_publication_cta}>
+              <div className="su-rs-pl-3">
+                <DrupalLinkButton href={node.su_publication_cta.url}>{node.su_publication_cta.title}</DrupalLinkButton>
+              </div>
+            </Conditional>
+
+          </div>
+        </div>
+{/* 
         {node.su_publication_topics && node.su_publication_topics.map(term=>
-          <div key={term.id}>{term.name}</div>
+          <div key={term.id} className="su-text-digital-red su-type-0">{term.name}</div>
         )}
-        <h1>{node.title}</h1>
 
         {node.su_publication_components && <Rows rows={node.su_publication_components} rowField="su_pubs_components"/>}
 
         {node.su_publication_citation && <Citation citation={node.su_publication_citation}/>}
         {node.su_publication_cta &&
-            <Link href={node.su_publication_cta.url}>{node.su_publication_cta.title}</Link>}
+            <Link href={node.su_publication_cta.url}>{node.su_publication_cta.title}</Link>} */}
       </article>
     </MainContentLayout>
   )

--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -21,74 +21,74 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
   return (
     <MainContentLayout pageTitle={node.title}>
       {console.log('node', node)}
-      <article {...props}>
-      {node.su_publication_topics && node.su_publication_topics.map(term=>
-        <div key={term.id} className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">{term.name}</div>
-      )}
-      <div className="md:su-grid su-grid-cols-6 su-gap-[40px]">
-          <div className="su-col-span-4">
-            <div className="su-rs-mb-7 md:su-w-11/12 ">
-
-              {node.su_publication_components && <Rows rows={node.su_publication_components} rowField="su_pubs_components"/>}
-            </div>
+        <article {...props}>
+        {node.su_publication_citation.citation_type.resourceIdObjMeta.drupal_internal__target_id && 
+          <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
+            {node.su_publication_citation.citation_type.resourceIdObjMeta.drupal_internal__target_id}
           </div>
+        }
+        <div className="md:su-grid su-grid-cols-6 su-gap-[40px] su-rs-mb-7">
+            <div className="su-col-span-4">
+              <div className="su-rs-mb-7 md:su-w-11/12 ">
 
-          <div className="su-col-span-2">
-            <div className="su-rs-pl-3 su-border-l su-border-black-10">
-              <Conditional showWhen={node.su_publication_citation.su_author.length > 0}>
-                <div className="su-rs-mb-2">
-                    <h2 className="su-type-0">Author(s)</h2>
-                    <div>
-                      {node.su_publication_citation.su_author && node.su_publication_citation.su_author.map((author, index) =>
-                        <div key={`citation-author-${index}`}>
-                          {author.given} {author.family}
-                        </div>
-                      )}
-                    </div>
-                </div>
-              </Conditional>
-
-              <Conditional showWhen={node.su_publication_citation.su_publisher}>
-                <div className="su-rs-mb-2">
-                  <h2 className="su-type-0">Publisher</h2>
-                  {node.su_publication_citation.su_publisher}
-                </div>
-              </Conditional>
-
-              <Conditional showWhen={node.su_publication_citation.su_year}>
-                <div className="su-rs-mb-4">
-                  <h2 className="su-type-0">Publication Date</h2>
-                  <Conditional showWhen={node.su_publication_citation.su_month && node.su_publication_citation.su_day}>
-                    {getMonthName(node.su_publication_citation.su_month)} {node.su_publication_citation.su_day}, {node.su_publication_citation.su_year}
-                  </Conditional>
-                  <Conditional showWhen={node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
-                    {node.su_publication_citation.su_month}, {node.su_publication_citation.su_year}
-                  </Conditional>
-                  <Conditional showWhen={!node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
-                    {node.su_publication_citation.su_year}
-                  </Conditional>
-                </div>
-              </Conditional>
+                {node.su_publication_components && <Rows rows={node.su_publication_components} rowField="su_pubs_components"/>}
+              </div>
             </div>
 
-            <Conditional showWhen={node.su_publication_cta}>
-              <div className="su-rs-pl-3">
-                <DrupalLinkButton href={node.su_publication_cta.url}>{node.su_publication_cta.title}</DrupalLinkButton>
-              </div>
-            </Conditional>
+            <div className="su-col-span-2">
+              <div className="su-rs-pl-3 su-border-l su-border-black-10">
+                <Conditional showWhen={node.su_publication_citation.su_author.length > 0}>
+                  <div className="su-rs-mb-2">
+                      <h2 className="su-type-0">Author(s)</h2>
+                      <div>
+                        {node.su_publication_citation.su_author && node.su_publication_citation.su_author.map((author, index) =>
+                          <div key={`citation-author-${index}`}>
+                            {author.given} {author.family}
+                          </div>
+                        )}
+                      </div>
+                  </div>
+                </Conditional>
 
+                <Conditional showWhen={node.su_publication_citation.su_publisher}>
+                  <div className="su-rs-mb-2">
+                    <h2 className="su-type-0">Publisher</h2>
+                    {node.su_publication_citation.su_publisher}
+                  </div>
+                </Conditional>
+
+                <Conditional showWhen={node.su_publication_citation.su_year}>
+                  <div className="su-rs-mb-4">
+                    <h2 className="su-type-0">Publication Date</h2>
+                    <Conditional showWhen={node.su_publication_citation.su_month && node.su_publication_citation.su_day}>
+                      {getMonthName(node.su_publication_citation.su_month)} {node.su_publication_citation.su_day}, {node.su_publication_citation.su_year}
+                    </Conditional>
+                    <Conditional showWhen={node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
+                      {node.su_publication_citation.su_month}, {node.su_publication_citation.su_year}
+                    </Conditional>
+                    <Conditional showWhen={!node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
+                      {node.su_publication_citation.su_year}
+                    </Conditional>
+                  </div>
+                </Conditional>
+              </div>
+
+              <Conditional showWhen={node.su_publication_cta}>
+                <div className="su-rs-pl-3">
+                  <DrupalLinkButton href={node.su_publication_cta.url}>{node.su_publication_cta.title}</DrupalLinkButton>
+                </div>
+              </Conditional>
+
+            </div>
+        </div>
+        <div className="su-border-t su-border-black-10">
+          <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-font-bold su-rs-pt-0">Related Topics</h2>
+          <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
+            {node.su_publication_topics && node.su_publication_topics.map((term, index) =>
+              <span key={term.id} className="su-text-digital-red su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">{(index ? ', ' : '') + term.name}</span>
+            )}
           </div>
         </div>
-{/* 
-        {node.su_publication_topics && node.su_publication_topics.map(term=>
-          <div key={term.id} className="su-text-digital-red su-type-0">{term.name}</div>
-        )}
-
-        {node.su_publication_components && <Rows rows={node.su_publication_components} rowField="su_pubs_components"/>}
-
-        {node.su_publication_citation && <Citation citation={node.su_publication_citation}/>}
-        {node.su_publication_cta &&
-            <Link href={node.su_publication_cta.url}>{node.su_publication_cta.title}</Link>} */}
       </article>
     </MainContentLayout>
   )

--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -21,11 +21,10 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 
   return (
     <MainContentLayout pageTitle={node.title}>
-      {/* {console.log('node', node)} */}
       <article {...props}>
-        <Conditional showWhen={node.su_publication_citation.citation_type}>
+        <Conditional showWhen={node.su_publication_citation?.citation_type?.label}>
           <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
-            {node.su_publication_citation.citation_type.resourceIdObjMeta.drupal_internal__target_id}
+            {node.su_publication_citation?.citation_type?.label}
           </div>
         </Conditional>
 
@@ -40,11 +39,11 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 
           <div className="su-col-span-2">
             <div className="lg:su-rs-pl-3 lg:su-border-l su-border-black-10">
-              <Conditional showWhen={node.su_publication_citation.su_author.length > 0}>
+              <Conditional showWhen={node.su_publication_citation?.su_author.length > 0}>
                 <div className="su-rs-mb-2">
                     <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Author(s)</h2>
                     <div>
-                      {node.su_publication_citation.su_author && node.su_publication_citation.su_author.map((author, index) =>
+                      {node.su_publication_citation?.su_author.map((author, index) =>
                         <div key={`citation-author-${index}` } className="su-text-16 md:su-text-18 2xl:su-text-19">
                           {author.given} {author.family}
                         </div>
@@ -53,55 +52,55 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
                 </div>
               </Conditional>
 
-              <Conditional showWhen={node.su_publication_citation.su_publisher}>
+              <Conditional showWhen={node.su_publication_citation?.su_publisher}>
                 <div className="su-rs-mb-2">
                   <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Publisher</h2>
                   <div className="su-text-16 md:su-text-18 2xl:su-text-19">
-                    {node.su_publication_citation.su_publisher}
+                    {node.su_publication_citation?.su_publisher}
                   </div>
                 </div>
               </Conditional>
 
-              <Conditional showWhen={node.su_publication_citation.su_journal_publisher}>
+              <Conditional showWhen={node.su_publication_citation?.su_journal_publisher}>
                 <div className="su-rs-mb-2">
                   <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Journal Name</h2>
                   <div className="su-text-16 md:su-text-18 2xl:su-text-19">
-                    {node.su_publication_citation.su_journal_publisher}
+                    {node.su_publication_citation?.su_journal_publisher}
                   </div>
                 </div>
               </Conditional>
 
-              <Conditional showWhen={node.su_publication_citation.su_year}>
+              <Conditional showWhen={node.su_publication_citation?.su_year}>
                 <div className="su-rs-mb-2">
                   <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Publication Date</h2>
-                  <Conditional showWhen={node.su_publication_citation.su_month && node.su_publication_citation.su_day}>
+                  <Conditional showWhen={node.su_publication_citation?.su_month && node.su_publication_citation?.su_day}>
                     <div className="su-text-16 md:su-text-18 2xl:su-text-19">
-                      {getMonthName(node.su_publication_citation.su_month)} {node.su_publication_citation.su_day}, {node.su_publication_citation.su_year}
+                      {getMonthName(node.su_publication_citation?.su_month)} {node.su_publication_citation?.su_day}, {node.su_publication_citation?.su_year}
                     </div>
                   </Conditional>
-                  <Conditional showWhen={node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
-                    {node.su_publication_citation.su_month}, {node.su_publication_citation.su_year}
+                  <Conditional showWhen={node.su_publication_citation?.su_month && !node.su_publication_citation?.su_day}>
+                    {node.su_publication_citation?.su_month}, {node.su_publication_citation?.su_year}
                   </Conditional>
-                  <Conditional showWhen={!node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
-                    {node.su_publication_citation.su_year}
+                  <Conditional showWhen={!node.su_publication_citation?.su_month && !node.su_publication_citation?.su_day}>
+                    {node.su_publication_citation?.su_year}
                   </Conditional>
                 </div>
               </Conditional>
               
-              <Conditional showWhen={node.su_publication_citation.su_genre}>
+              <Conditional showWhen={node.su_publication_citation?.su_genre}>
                 <div className="su-rs-mb-2">
                   <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">Type of Dissertation</h2>
                   <div className="su-text-16 md:su-text-18 2xl:su-text-19">
-                    {node.su_publication_citation.su_genre}
+                    {node.su_publication_citation?.su_genre}
                   </div>
                 </div>
               </Conditional>
 
-              <Conditional showWhen={node.su_publication_citation.su_doi}>
+              <Conditional showWhen={node.su_publication_citation?.su_doi}>
                 <div className="su-rs-mb-2">
                   <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-mb-01em">DOI</h2>
                   <div className="su-text-16 md:su-text-18 2xl:su-text-19">
-                    {node.su_publication_citation.su_doi}
+                    {node.su_publication_citation?.su_doi}
                   </div>
                 </div>
               </Conditional>
@@ -148,9 +147,9 @@ export const NodeStanfordPublicationCard = ({node, ...props}: PublicationNodePro
     <article {...props}>
       <Card
         superHeader={
-          <Conditional showWhen={node.su_publication_citation.citation_type}>
-            <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-neg2">
-              {node?.su_publication_citation?.citation_type?.resourceIdObjMeta?.drupal_internal__target_id}
+          <Conditional showWhen={node.su_publication_citation?.citation_type?.label}>
+            <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
+              {node.su_publication_citation?.citation_type?.label}
             </div>
           </Conditional>
         }
@@ -169,10 +168,6 @@ export const NodeStanfordPublicationCard = ({node, ...props}: PublicationNodePro
           </div>
         }
       />
-      {/* {console.log('node', node)} */}
-      {/* <Link href={node.path.alias} className="su-no-underline su-text-cardinal-red hover:su-underline hover:su-text-black">
-        <h2 className="su-text-cardinal-red">{node.title}</h2>
-      </Link> */}
     </article>
   )
 }

--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -21,74 +21,78 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
   return (
     <MainContentLayout pageTitle={node.title}>
       {console.log('node', node)}
-        <article {...props}>
-        {node.su_publication_citation.citation_type.resourceIdObjMeta.drupal_internal__target_id && 
+      <article {...props}>
+        <Conditional showWhen={node.su_publication_citation.citation_type}>
           <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
             {node.su_publication_citation.citation_type.resourceIdObjMeta.drupal_internal__target_id}
           </div>
-        }
-        <div className="md:su-grid su-grid-cols-6 su-gap-[40px] su-rs-mb-7">
+        </Conditional>
+
+        <div className="lg:su-grid su-grid-cols-6 su-gap-[40px] su-rs-mb-7">
+          <Conditional showWhen={node.su_publication_components.length > 0}>
             <div className="su-col-span-4">
               <div className="su-rs-mb-7 md:su-w-11/12 ">
-
                 {node.su_publication_components && <Rows rows={node.su_publication_components} rowField="su_pubs_components"/>}
               </div>
             </div>
+          </Conditional>
 
-            <div className="su-col-span-2">
-              <div className="su-rs-pl-3 su-border-l su-border-black-10">
-                <Conditional showWhen={node.su_publication_citation.su_author.length > 0}>
-                  <div className="su-rs-mb-2">
-                      <h2 className="su-type-0">Author(s)</h2>
-                      <div>
-                        {node.su_publication_citation.su_author && node.su_publication_citation.su_author.map((author, index) =>
-                          <div key={`citation-author-${index}`}>
-                            {author.given} {author.family}
-                          </div>
-                        )}
-                      </div>
-                  </div>
-                </Conditional>
-
-                <Conditional showWhen={node.su_publication_citation.su_publisher}>
-                  <div className="su-rs-mb-2">
-                    <h2 className="su-type-0">Publisher</h2>
-                    {node.su_publication_citation.su_publisher}
-                  </div>
-                </Conditional>
-
-                <Conditional showWhen={node.su_publication_citation.su_year}>
-                  <div className="su-rs-mb-4">
-                    <h2 className="su-type-0">Publication Date</h2>
-                    <Conditional showWhen={node.su_publication_citation.su_month && node.su_publication_citation.su_day}>
-                      {getMonthName(node.su_publication_citation.su_month)} {node.su_publication_citation.su_day}, {node.su_publication_citation.su_year}
-                    </Conditional>
-                    <Conditional showWhen={node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
-                      {node.su_publication_citation.su_month}, {node.su_publication_citation.su_year}
-                    </Conditional>
-                    <Conditional showWhen={!node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
-                      {node.su_publication_citation.su_year}
-                    </Conditional>
-                  </div>
-                </Conditional>
-              </div>
-
-              <Conditional showWhen={node.su_publication_cta}>
-                <div className="su-rs-pl-3">
-                  <DrupalLinkButton href={node.su_publication_cta.url}>{node.su_publication_cta.title}</DrupalLinkButton>
+          <div className="su-col-span-2">
+            <div className="lg:su-rs-pl-3 lg:su-border-l su-border-black-10">
+              <Conditional showWhen={node.su_publication_citation.su_author.length > 0}>
+                <div className="su-rs-mb-2">
+                    <h2 className="su-text-16 md:su-text-18 2xl:su-text-19">Author(s)</h2>
+                    <div>
+                      {node.su_publication_citation.su_author && node.su_publication_citation.su_author.map((author, index) =>
+                        <div key={`citation-author-${index}`}>
+                          {author.given} {author.family}
+                        </div>
+                      )}
+                    </div>
                 </div>
               </Conditional>
 
+              <Conditional showWhen={node.su_publication_citation.su_publisher}>
+                <div className="su-rs-mb-2">
+                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19">Publisher</h2>
+                  {node.su_publication_citation.su_publisher}
+                </div>
+              </Conditional>
+
+              <Conditional showWhen={node.su_publication_citation.su_year}>
+                <div className="su-rs-mb-4">
+                  <h2 className="su-text-16 md:su-text-18 2xl:su-text-19">Publication Date</h2>
+                  <Conditional showWhen={node.su_publication_citation.su_month && node.su_publication_citation.su_day}>
+                    {getMonthName(node.su_publication_citation.su_month)} {node.su_publication_citation.su_day}, {node.su_publication_citation.su_year}
+                  </Conditional>
+                  <Conditional showWhen={node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
+                    {node.su_publication_citation.su_month}, {node.su_publication_citation.su_year}
+                  </Conditional>
+                  <Conditional showWhen={!node.su_publication_citation.su_month && !node.su_publication_citation.su_day}>
+                    {node.su_publication_citation.su_year}
+                  </Conditional>
+                </div>
+              </Conditional>
             </div>
-        </div>
-        <div className="su-border-t su-border-black-10">
-          <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-font-bold su-rs-pt-0">Related Topics</h2>
-          <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
-            {node.su_publication_topics && node.su_publication_topics.map((term, index) =>
-              <span key={term.id} className="su-text-digital-red su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">{(index ? ', ' : '') + term.name}</span>
-            )}
+
+            {node.su_publication_cta &&
+              <div className="lg:su-rs-pl-3">
+                <DrupalLinkButton href={node.su_publication_cta.url}>{node.su_publication_cta.title}</DrupalLinkButton>
+              </div>            
+            }
           </div>
         </div>
+        
+        <Conditional showWhen={node.su_publication_topics.length > 0}>
+          <div className="su-border-t su-border-black-10">
+            <h2 className="su-text-16 md:su-text-18 2xl:su-text-19 su-font-bold su-rs-pt-0">Related Topics</h2>
+            <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
+              {node.su_publication_topics && node.su_publication_topics.map((term, index) =>
+                <span key={term.id} className="su-text-digital-red su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">{(index ? ', ' : '') + term.name}</span>
+              )}
+            </div>
+          </div>
+        </Conditional>
       </article>
     </MainContentLayout>
   )

--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -3,7 +3,8 @@ import Link from "next/link";
 import {DrupalLinkButton} from "@/components/simple/link";
 import {Rows} from "@/components/paragraphs/row";
 import {MainContentLayout} from "@/components/layouts/main-content-layout";
-import Conditional from "../simple/conditional";
+import {Card} from "@/components/patterns/card";
+import Conditional from "@/components/simple/conditional";
 
 interface PublicationNodeProps {
   node: Publication
@@ -20,7 +21,7 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 
   return (
     <MainContentLayout pageTitle={node.title}>
-      {console.log('node', node)}
+      {/* {console.log('node', node)} */}
       <article {...props}>
         <Conditional showWhen={node.su_publication_citation.citation_type}>
           <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
@@ -132,20 +133,46 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 export const NodeStanfordPublicationListItem = ({node, ...props}: PublicationNodeProps) => {
   return (
     <article {...props}>
+      {console.log('node', node)}
       <Link href={node.path.alias}>
         <h2 className="su-text-cardinal-red">{node.title}</h2>
       </Link>
+      {node.su_publication_citation && <Citation citation={node.su_publication_citation}/>}
     </article>
   )
 }
 
 export const NodeStanfordPublicationCard = ({node, ...props}: PublicationNodeProps) => {
+  const topics = node.su_publication_topics?.filter(topic => topic.name?.length > 0) ?? [];
   return (
-    <article className="su-shadow-lg" {...props}>
-      <Link href={node.path.alias}
-                  className="su-no-underline su-text-cardinal-red hover:su-underline hover:su-text-black">
+    <article {...props}>
+      <Card
+        superHeader={
+          <Conditional showWhen={node.su_publication_citation.citation_type}>
+            <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-neg2">
+              {node?.su_publication_citation?.citation_type?.resourceIdObjMeta?.drupal_internal__target_id}
+            </div>
+          </Conditional>
+        }
+        header={
+          <Link className="su-text-black hover:su-underline" href={node.path.alias}>
+            {node.title}
+          </Link>
+        }
+        footer={
+          <div>
+            {topics.map((topic, index) =>
+              <span key={topic.id}>
+                {(index ? ', ' : '') + topic.name}
+              </span>
+          )}
+          </div>
+        }
+      />
+      {/* {console.log('node', node)} */}
+      {/* <Link href={node.path.alias} className="su-no-underline su-text-cardinal-red hover:su-underline hover:su-text-black">
         <h2 className="su-text-cardinal-red">{node.title}</h2>
-      </Link>
+      </Link> */}
     </article>
   )
 }

--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -132,7 +132,6 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 export const NodeStanfordPublicationListItem = ({node, ...props}: PublicationNodeProps) => {
   return (
     <article {...props}>
-      {console.log('node', node)}
       <Link href={node.path.alias}>
         <h2 className="su-text-cardinal-red">{node.title}</h2>
       </Link>

--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -20,7 +20,7 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 
   return (
     <MainContentLayout pageTitle={node.title}>
-      {console.log('node', node)}
+      {/* {console.log('node', node)} */}
       <article {...props}>
         <Conditional showWhen={node.su_publication_citation.citation_type}>
           <div className="su-text-16 md:su-text-18 2xl:su-text-19 su-rs-mb-2">
@@ -31,7 +31,7 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
         <div className="lg:su-grid su-grid-cols-6 su-gap-[40px] su-rs-mb-7">
           <Conditional showWhen={node.su_publication_components.length > 0}>
             <div className="su-col-span-4">
-              <div className="su-rs-mb-7 md:su-w-11/12 ">
+              <div className="su-rs-mb-7 lg:su-w-11/12 ">
                 {node.su_publication_components && <Rows rows={node.su_publication_components} rowField="su_pubs_components"/>}
               </div>
             </div>

--- a/src/components/nodes/node-stanford-publication.tsx
+++ b/src/components/nodes/node-stanford-publication.tsx
@@ -1,5 +1,5 @@
 import {DrupalPublicationCitation, Publication} from "../../types/drupal";
-import {DrupalLink} from "@/components/simple/link";
+import Link from "next/link";
 import {Rows} from "@/components/paragraphs/row";
 import {MainContentLayout} from "@/components/layouts/main-content-layout";
 
@@ -20,7 +20,7 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 
         {node.su_publication_citation && <Citation citation={node.su_publication_citation}/>}
         {node.su_publication_cta &&
-            <DrupalLink href={node.su_publication_cta.url}>{node.su_publication_cta.title}</DrupalLink>}
+            <Link href={node.su_publication_cta.url}>{node.su_publication_cta.title}</Link>}
       </article>
     </MainContentLayout>
   )
@@ -29,9 +29,9 @@ export const NodeStanfordPublication = ({node, ...props}: PublicationNodeProps) 
 export const NodeStanfordPublicationListItem = ({node, ...props}: PublicationNodeProps) => {
   return (
     <article {...props}>
-      <DrupalLink href={node.path.alias}>
+      <Link href={node.path.alias}>
         <h2 className="su-text-cardinal-red">{node.title}</h2>
-      </DrupalLink>
+      </Link>
     </article>
   )
 }
@@ -39,10 +39,10 @@ export const NodeStanfordPublicationListItem = ({node, ...props}: PublicationNod
 export const NodeStanfordPublicationCard = ({node, ...props}: PublicationNodeProps) => {
   return (
     <article className="su-shadow-lg" {...props}>
-      <DrupalLink href={node.path.alias}
+      <Link href={node.path.alias}
                   className="su-no-underline su-text-cardinal-red hover:su-underline hover:su-text-black">
         <h2 className="su-text-cardinal-red">{node.title}</h2>
-      </DrupalLink>
+      </Link>
     </article>
   )
 }

--- a/src/components/patterns/card.tsx
+++ b/src/components/patterns/card.tsx
@@ -8,7 +8,7 @@ import Conditional from "@/components/simple/conditional";
 interface CardProps {
   video?: ReactNodeLike
   image?: ReactNodeLike
-  superHeader?: string
+  superHeader?: any
   header?: any
   footer?: ReactNodeLike
   body?: string


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [SUL23-42](https://stanfordits.atlassian.net/browse/SUL23-42): FE-DEV | Build "Publication" content display in NextJS
- [SUL23-49](https://stanfordits.atlassian.net/browse/SUL23-49): FE-DEV | Build "Publication" card display in NextJS
- Per our discussion during SUL standup, this PR is only focusing on the Publication node and card displays. See [SUL23-56](https://stanfordits.atlassian.net/browse/SUL23-56) for future work on the Publications list display.

# Review By (Date)
- When convenient

# Steps to Test

1. Checkout branch or view preview at https://deploy-preview-47--stanford-library.netlify.app/
2. Create example publications and a basic page with publication teasers, or view examples:
https://deploy-preview-47--stanford-library.netlify.app/publications/white-paper/sws-test-pub-217-article-newspapermagazine
https://deploy-preview-47--stanford-library.netlify.app/publications/sws-test-pub-217-book-no-content
https://deploy-preview-47--stanford-library.netlify.app/sws-test-217-publication-teasers
3. Review styles
4. Review code 🧀 


[SUL23-42]: https://stanfordits.atlassian.net/browse/SUL23-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SUL23-49]: https://stanfordits.atlassian.net/browse/SUL23-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUL23-56]: https://stanfordits.atlassian.net/browse/SUL23-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ