### PR TITLE
NoJira: Cache indefinitely

### DIFF
--- a/app/(public)/[...slug]/page.tsx
+++ b/app/(public)/[...slug]/page.tsx
@@ -19,7 +19,7 @@ import UnpublishedBanner from "@/components/patterns/unpublished-banner";
 
 // Opt out of caching for all data requests in the route segment
 export const dynamic = 'force-static';
-// Cache dynamic page render indefinitely. 
+// Cache static page render indefinitely. Let on-demand revalidation do it's thing.
 export const revalidate = false;
 
 class RedirectError extends Error {

--- a/app/(public)/[...slug]/page.tsx
+++ b/app/(public)/[...slug]/page.tsx
@@ -19,7 +19,8 @@ import UnpublishedBanner from "@/components/patterns/unpublished-banner";
 
 // Opt out of caching for all data requests in the route segment
 export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+// Cache dynamic page render indefinitely. 
+export const revalidate = false;
 
 class RedirectError extends Error {
   constructor(public message: string) {

--- a/app/(public)/[...slug]/page.tsx
+++ b/app/(public)/[...slug]/page.tsx
@@ -18,7 +18,7 @@ import {isDraftMode} from "@/lib/drupal/is-draft-mode";
 import UnpublishedBanner from "@/components/patterns/unpublished-banner";
 
 // Opt out of caching for all data requests in the route segment
-export const dynamic = 'force-dynamic';
+export const dynamic = 'force-static';
 // Cache dynamic page render indefinitely. 
 export const revalidate = false;
 


### PR DESCRIPTION
# Summary
- https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
- Right now every request to the production site is being SSR and served

# Review By (Date)
- Soon

# Urgency
- High

# Steps to Test

1. Navigate to: https://library.stanford.edu/research-support/subject-specialists
2. Open up your browser tools and inspect the response headers
3. You'll see `X-Vercel-Cache: MISS`
4. Refresh the page and inspect the headers again
5. You'll see `X-Vercel-Cache: MISS` again
6. Open up the [preview build](https://su-library-git-nojira-rtfm-stanford-libraries.vercel.app/research-support/subject-specialists)
7. Navigate to an interior page
8. Open up your browser tools and inspect the response headers
9. If you see `X-Vercel-Cache: MISS` refresh the page
10. You should be seeing `X-Vercel-Cache: HIT`
11. For bonus points, create a new test page and publish it in the CMS
12. Visit the new page in the preview build
13. See cache miss on the first pass
14. See cache hit on the second refresh

# Question?
How do 'dynamic pages' like the research subject specialists page or pages with views on them get cleared in the revalidate? Does Drupal send the revalidation API call to the specialist page as well as the person page when you change someone?

Scenario: Unpublish Hanna Ahn
Desired outcome: Subject Specialists page and Hannah Ahn page get revalidated. The Subject Specialist page gets statically rendered again on the next request, and the Hanna Ahn page is 404'd.