### PR TITLE
SUL23-428 - events ratio to 4/3

### DIFF
--- a/src/components/node/stanford-event/card.tsx
+++ b/src/components/node/stanford-event/card.tsx
@@ -32,7 +32,7 @@ const StanfordEventCard = ({node, h3Heading, ...props}: Props) => {
     <article {...props} className="@container mx-auto">
       {imageUrl &&
         <div
-          className={"overflow-hidden aspect-[16/9] relative"}
+          className={"overflow-hidden aspect-[4/3] relative"}
           aria-hidden="true"
         >
           <Image


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Ticket: https://stanfordits.atlassian.net/browse/SUL23-428
- Swapped 16/9 event card images for 4/3. 

# Review By (Date)
- When does this need to be reviewed by?
- April 19

# Urgency
- How critical is this PR?

# Steps to Test

1. Review on build. https://su-library-git-sul23-428-event-images-d63b14-stanford-libraries.vercel.app/news-and-events

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
