### PR TITLE
SUL23-461: Moved button for focus order

### DIFF
--- a/src/components/patterns/modals/interception-modal.tsx
+++ b/src/components/patterns/modals/interception-modal.tsx
@@ -49,14 +49,7 @@ const InterceptionModal = ({children, ...props}: PropsWithChildren<any>) => {
         {...props}
       >
         <ReactFocusLock returnFocus>
-          <div
-            ref={wrapper}
-            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-11/12 sm:w-10/12 md:w-8/12 lg:w-1/2 p-6"
-          >
-            {children}
-          </div>
-
-          <button
+        <button
             type="button"
             onClick={onDismiss}
             className="fixed right-50 top-50 text-white flex hocus:underline"
@@ -64,6 +57,12 @@ const InterceptionModal = ({children, ...props}: PropsWithChildren<any>) => {
             Close<span className="sr-only"> Overlay</span>
             <XMarkIcon className="ml-5" width={25}/>
           </button>
+          <div
+            ref={wrapper}
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-11/12 sm:w-10/12 md:w-8/12 lg:w-1/2 p-6"
+          >
+            {children}
+          </div>
         </ReactFocusLock>
       </dialog>
 

--- a/src/components/patterns/modals/interception-modal.tsx
+++ b/src/components/patterns/modals/interception-modal.tsx
@@ -44,6 +44,7 @@ const InterceptionModal = ({children, ...props}: PropsWithChildren<any>) => {
       <dialog
         ref={overlay}
         className="modal fixed w-screen h-full overscroll-contain overflow-y-scroll overflow-x-hidden top-0 left-0 items-center justify-center z-[10000] bg-black-true bg-opacity-[90%] flex"
+        aria-modal="true"
         onClick={onClick}
         open
         {...props}

--- a/src/components/patterns/modals/modal.tsx
+++ b/src/components/patterns/modals/modal.tsx
@@ -44,12 +44,6 @@ const Modal = ({children, isOpen, onClose, labelledBy}: ModalProps) => {
           className={"modal fixed w-screen h-full overscroll-contain overflow-y-scroll overflow-x-hidden top-0 left-0 items-center justify-center z-[10000] bg-black-true bg-opacity-[90%] flex"}
         >
           <div className={"absolute w-screen h-full basefont-19 pointer-events-auto"}>
-            <div
-              className="h-5/6 w-11/12 md:h-4/5 md:w-8/12 mx-auto mt-[5%]"
-            >
-              {children}
-            </div>
-
             <div>
               <button
                 type="button"
@@ -58,7 +52,12 @@ const Modal = ({children, isOpen, onClose, labelledBy}: ModalProps) => {
               >
                 Close<span className="sr-only"> Overlay</span>
                 <XMarkIcon className="ml-10 mt-[-3px]" width={25}/>
-              </button>
+                </button>
+              </div>
+            <div
+              className="h-5/6 w-11/12 md:h-4/5 md:w-8/12 mx-auto mt-[5%]"
+            >
+              {children}
             </div>
           </div>
         </div>

--- a/src/components/patterns/modals/modal.tsx
+++ b/src/components/patterns/modals/modal.tsx
@@ -38,7 +38,7 @@ const Modal = ({children, isOpen, onClose, labelledBy}: ModalProps) => {
   }
 
   return (
-    <dialog className="w-full h-full" open ref={animationParent} aria-labelledby={labelledBy}>
+    <dialog aria-modal="true" className="w-full h-full" open ref={animationParent} aria-labelledby={labelledBy}>
       <ReactFocusLock returnFocus>
         <div
           className={"modal fixed w-screen h-full overscroll-contain overflow-y-scroll overflow-x-hidden top-0 left-0 items-center justify-center z-[10000] bg-black-true bg-opacity-[90%] flex"}
@@ -48,7 +48,7 @@ const Modal = ({children, isOpen, onClose, labelledBy}: ModalProps) => {
               <button
                 type="button"
                 onClick={onClose}
-                className={"absolute right-50 top-50 text-white flex"}
+                className={"absolute right-50 top-50 text-white flex hocus:underline"}
               >
                 Close<span className="sr-only"> Overlay</span>
                 <XMarkIcon className="ml-10 mt-[-3px]" width={25}/>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Moved the close button higher up within the html to better support focus order in a dialog. 

# Review By (Date)
- 5/22

# Urgency
- normal

# Steps to Test

1. Look at the build - https://su-library-git-sul23-461-focus-order-stanford-libraries.vercel.app/people/zoe-dilles
2. Try the search modal on any page.
3. Verify the close button is before the form for focus.
4. Go to this page: https://su-library-git-sul23-461-focus-order-stanford-libraries.vercel.app/people/zoe-dilles
5. Click the appointment scheduler.
6. Verify the close button is before the form for focus.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
[- SUL23-461](https://stanfordits.atlassian.net/browse/SUL23-461)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
