### PR TITLE
SUL23-457: Update entity reference card lists to be in a <ul><li>

### DIFF
--- a/src/components/paragraph/stanford-entity.tsx
+++ b/src/components/paragraph/stanford-entity.tsx
@@ -78,8 +78,6 @@ const StanfordEntity = async ({
           )
         }
 
-
-
         {link?.url &&
           <DrupalLinkButton href={link?.url} className="block mx-auto" {...linkAttributes}>
             {link.title}

--- a/src/components/paragraph/stanford-entity.tsx
+++ b/src/components/paragraph/stanford-entity.tsx
@@ -61,13 +61,13 @@ const StanfordEntity = async ({
         }
 
         {entities &&
-          <div className={`mb-40 grid gap-[90px] ${gridClass}`} aria-live="polite">
+          <ul className={`list-unstyled mb-40 grid gap-[90px] ${gridClass}`} aria-live="polite">
             {entities.map(item =>
-              <div key={item.id} className="mx-auto w-full">
+              <li key={item.id} className="mx-auto w-full">
                 <NodeCardDisplay node={item} h3Heading={!!headline}/>
-              </div>
+              </li>
             )}
-          </div>
+          </ul>
         }
         {link?.url &&
           <DrupalLinkButton href={link?.url} className="block mx-auto" {...linkAttributes}>

--- a/src/components/paragraph/stanford-entity.tsx
+++ b/src/components/paragraph/stanford-entity.tsx
@@ -60,15 +60,26 @@ const StanfordEntity = async ({
           <div className="mb-40">{formatHtml(description)}</div>
         }
 
-        {entities &&
+        {entities?.length > 1 ? (
           <ul className={`list-unstyled mb-40 grid gap-[90px] ${gridClass}`} aria-live="polite">
-            {entities.map(item =>
+            {entities.map((item, index) => ( 
               <li key={item.id} className="mx-auto w-full">
-                <NodeCardDisplay node={item} h3Heading={!!headline}/>
-              </li>
-            )}
+                <NodeCardDisplay node={item} h3Heading={headline}/>
+              </li>)
+            )
+            }
           </ul>
+          )
+          :
+          (
+            <div className="mx-auto w-full">
+              <NodeCardDisplay node={entities[0]} h3Heading={headline}/>
+            </div>
+          )
         }
+
+
+
         {link?.url &&
           <DrupalLinkButton href={link?.url} className="block mx-auto" {...linkAttributes}>
             {link.title}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the entity reference list structure to a `ul li` from a `div`

# Review By (Date)
- 5/22

# Urgency
- normal

# Steps to Test

1. Open the testing site.
2. The library pages have a `Meet the Staff` list that shows the change: https://su-library-git-sul23-457-card-lists-stanford-libraries.vercel.app/libraries/branner-earth-sciences-library-map-collections
3. Another example is on this page: https://su-library-git-sul23-457-card-lists-stanford-libraries.vercel.app/research-support/subject-specialists

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
[- SUL23-457](https://stanfordits.atlassian.net/browse/SUL23-457)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
