### PR TITLE
SUL23-467: Changed line height on News and Event cards

### DIFF
--- a/src/components/node/stanford-event/card.tsx
+++ b/src/components/node/stanford-event/card.tsx
@@ -78,7 +78,7 @@ const StanfordEventCard = ({node, h3Heading, ...props}: Props) => {
         </div>
 
         <div className="flex flex-col gap-[.5rem]">
-          <HeadingElement className="text-m0 order-2">
+          <HeadingElement className="text-m0 order-2 leading-cozy">
             <Link href={goToUrl}
                   className="text-black-true hover:text-brick-dark underline hover:no-underline">
               {node.title}

--- a/src/components/node/stanford-news/card.tsx
+++ b/src/components/node/stanford-news/card.tsx
@@ -29,7 +29,7 @@ const StanfordNewsCard = ({node, h3Heading, ...props}: Props) => {
         </div>
       }
 
-      <HeadingElement className="text-m0 order-last">
+      <HeadingElement className="text-m0 order-last leading-cozy">
         <Link href={goToUrl}
               className="text-black-true hover:text-brick-dark underline hover:no-underline">
           {node.title}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed line height on headings for the News and Events cards.

# Review By (Date)
- 5/22

# Urgency
- Normal

# Steps to Test

1. Open the Vercel site.
1. Look at the cards for News and Event on the homepage: https://su-library-git-sul23-467-line-height-stanford-libraries.vercel.app/
3. Verify the heading/title is `1.4` and not `1.2`.
4. The cards are all over the site and can be seen on the Library individual pages too. 

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
[- SUL23-467](https://stanfordits.atlassian.net/browse/SUL23-467)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
