### PR TITLE
SUL23-650 | add Reservation not required to places to study with no reservation button

### DIFF
--- a/src/components/views/sul-study-place/filtering-table/study-place-filtering-table.tsx
+++ b/src/components/views/sul-study-place/filtering-table/study-place-filtering-table.tsx
@@ -240,7 +240,7 @@ const StudyPlaceFilteringTable = ({items}: Props) => {
                   )}
                 </Td>
                 <Td className="block w-auto sm:border-b sm:border-black-40 md:text-left lg:table-cell lg:w-1/5">
-                  {item.libCalId && (
+                  {item.libCalId ? (
                     <a
                       href={`https://appointments.library.stanford.edu/space/${item.libCalId}`}
                       className="button mb-16 w-fit whitespace-nowrap border border-solid border-cardinal-red bg-white py-[4px] text-16 leading-[22px] text-cardinal-red hocus:bg-cardinal-red hocus:text-white hocus:shadow-button md:w-full lg:mb-0 lg:w-fit"
@@ -252,9 +252,9 @@ const StudyPlaceFilteringTable = ({items}: Props) => {
                         </div>
                       </div>
                     </a>
+                  ) : (
+                    <p>Reservation not required</p>
                   )}
-                  {/* Without this, the responsive table library injects a "&nbsp;". */}
-                  {""}
                 </Td>
               </Tr>
             ))}

--- a/src/components/views/sul-study-place/filtering-table/study-place-filtering-table.tsx
+++ b/src/components/views/sul-study-place/filtering-table/study-place-filtering-table.tsx
@@ -240,7 +240,7 @@ const StudyPlaceFilteringTable = ({items}: Props) => {
                   )}
                 </Td>
                 <Td className="block w-auto sm:border-b sm:border-black-40 md:text-left lg:table-cell lg:w-1/5">
-                  {item.libCalId ? (
+                  {item.libCalId && (
                     <a
                       href={`https://appointments.library.stanford.edu/space/${item.libCalId}`}
                       className="button mb-16 w-fit whitespace-nowrap border border-solid border-cardinal-red bg-white py-[4px] text-16 leading-[22px] text-cardinal-red hocus:bg-cardinal-red hocus:text-white hocus:shadow-button md:w-full lg:mb-0 lg:w-fit"
@@ -252,9 +252,8 @@ const StudyPlaceFilteringTable = ({items}: Props) => {
                         </div>
                       </div>
                     </a>
-                  ) : (
-                    <p>Reservation not required</p>
                   )}
+                  {!item.libCalId && <p>Reservation not required</p>}
                 </Td>
               </Tr>
             ))}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- add Reservation not required to places to study with no reservation button

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to Places to Study
4. Verify that the "Reservation not required" text appears when there is no reservation link available 
5. Review code

# Associated Issues and/or People
- SUL23-650