### PR TITLE
SUL23-665 | resolve overlapping card image for certain breakpoints

### DIFF
--- a/src/components/paragraph/stanford-card.tsx
+++ b/src/components/paragraph/stanford-card.tsx
@@ -6,6 +6,7 @@ import Oembed from "@/components/patterns/elements/oembed"
 import {buildUrl} from "@/lib/drupal/utils"
 import {MediaImage, Maybe, Link as LinkType} from "@/lib/gql/__generated__/drupal.d"
 import {ElementType, HTMLAttributes} from "react"
+import {twMerge} from "tailwind-merge"
 
 type Props = HTMLAttributes<HTMLDivElement> & {
   header?: Maybe<string>
@@ -52,7 +53,10 @@ const StanfordCard = ({
   }
 
   return (
-    <div className={"relative" + (!isHorizontal ? " centered mx-auto w-full lg:max-w-[980px]" : "")} {...props}>
+    <div
+      className={twMerge("relative", !isHorizontal ? "centered mx-auto w-full lg:max-w-[980px]" : "p-0 md:rs-pt-5")}
+      {...props}
+    >
       {isHorizontal && (
         <HorizontalCard
           video={videoUrl && <Oembed url={videoUrl} className="h-full" />}

--- a/src/components/patterns/horizontal-card.tsx
+++ b/src/components/patterns/horizontal-card.tsx
@@ -53,7 +53,7 @@ const HorizontalCard = ({
   return (
     <div className="relative" {...props} ref={ref}>
       {fullWidth && (
-        <div className={"absolute left-0 top-0 z-[-10] ml-[calc(-50vw+50%)] h-full w-screen"}>
+        <div className="absolute left-0 top-0 z-[-10] ml-[calc(-50vw+50%)] h-full w-screen">
           <div className="relative h-full w-full bg-black-true" {...props}>
             <CardSprinkles position={backgroundSprinkles} />
           </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-665 | resolve overlapping card image for certain breakpoints

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to preview: https://su-library-git-bug-sul23-665-card-stanford-libraries.vercel.app/libraries/east-asia-library
2. Test different screen sizes and confirm that the horizontal card image doesn't overlap the paragraph items above
3. Review code

# Associated Issues and/or People
- SUL23-665 | resolve overlapping card image for certain breakpoints