### PR TITLE
nojira | fix media fig caption error

### DIFF
--- a/src/lib/format-html.tsx
+++ b/src/lib/format-html.tsx
@@ -10,7 +10,6 @@ import Oembed from "@/components/patterns/elements/oembed"
 import {twMerge} from "tailwind-merge"
 import {ElementType} from "react"
 import type {DOMNode} from "html-dom-parser"
-import clsx from "clsx"
 
 const options: HTMLReactParserOptions = {
   replace: domNode => {
@@ -73,7 +72,7 @@ const options: HTMLReactParserOptions = {
           return <pre {...nodeProps}>{domToReact(domNode.children as DOMNode[], options)}</pre>
 
         case "figure":
-          nodeProps.className = clsx(
+          nodeProps.className = twMerge(
             nodeProps.className,
             "table mb-20",
             !nodeProps.className.includes("float") && "w-full"

--- a/src/lib/format-html.tsx
+++ b/src/lib/format-html.tsx
@@ -10,6 +10,7 @@ import Oembed from "@/components/patterns/elements/oembed"
 import {twMerge} from "tailwind-merge"
 import {ElementType} from "react"
 import type {DOMNode} from "html-dom-parser"
+import clsx from "clsx"
 
 const options: HTMLReactParserOptions = {
   replace: domNode => {
@@ -249,6 +250,3 @@ const cleanMediaMarkup = (node: Element) => {
 
 const formatHtml = (html?: string) => parse(html ?? "", options)
 export default formatHtml
-function clsx(arg0: string, className: string, arg2: string | boolean): string | boolean {
-  throw new Error("Function not implemented.")
-}

--- a/src/lib/format-html.tsx
+++ b/src/lib/format-html.tsx
@@ -72,9 +72,9 @@ const options: HTMLReactParserOptions = {
           return <pre {...nodeProps}>{domToReact(domNode.children as DOMNode[], options)}</pre>
 
         case "figure":
-          nodeProps.className = twMerge(
-            "table mb-20",
+          nodeProps.className = clsx(
             nodeProps.className,
+            "table mb-20",
             !nodeProps.className.includes("float") && "w-full"
           )
           delete nodeProps.role
@@ -249,3 +249,6 @@ const cleanMediaMarkup = (node: Element) => {
 
 const formatHtml = (html?: string) => parse(html ?? "", options)
 export default formatHtml
+function clsx(arg0: string, className: string, arg2: string | boolean): string | boolean {
+  throw new Error("Function not implemented.")
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- nojira | fix media fig caption error

# Review By (Date)
- Before release

# Criticality
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Spin up local
3. Navigate to `/news/les-paroles-politiques-cherubini-celebrates-louis-xviii`
4. Verify that the embed spans full width and the media image captions appear normal
5. Review code

# Associated Issues and/or People
- SUL23-663
