### PR TITLE
SUL23-698 | fixup about us menu item display

### DIFF
--- a/src/components/menu/fallback-main-menu.tsx
+++ b/src/components/menu/fallback-main-menu.tsx
@@ -27,7 +27,7 @@ const MenuItem = ({url, title}: MenuItemType) => {
         href={linkUrl}
         className="flex w-full items-center p-20 text-white no-underline hover:bg-black hover:text-white hover:underline focus:bg-black focus:text-white lg:text-black-true lg:hover:bg-transparent lg:hover:text-black-true lg:focus:bg-transparent lg:focus:text-black-true lg:focus:underline"
       >
-        <div className="pl-30 lg:pl-0">{title}</div>
+        <div className="shrink-0 pl-30 lg:pl-0">{title}</div>
       </Link>
     </li>
   )

--- a/src/components/menu/main-menu.tsx
+++ b/src/components/menu/main-menu.tsx
@@ -204,7 +204,7 @@ const MenuItem = ({
           )}
           aria-current={activeTrail.at(-1) === id ? "page" : undefined}
         >
-          <div className={twMerge("pl-30 lg:pl-0", titleSpacing[menuLevel])}>{title}</div>
+          <div className={twMerge("shrink-0 pl-30 lg:pl-0", titleSpacing[menuLevel])}>{title}</div>
         </Link>
       )}
 
@@ -218,7 +218,7 @@ const MenuItem = ({
           onClick={toggleSubmenu}
           aria-expanded={submenuOpen ? "true" : "false"}
         >
-          <span className={twMerge("pl-30 lg:pl-0", titleSpacing[menuLevel])}>{title}</span>
+          <span className={twMerge("shrink-0 pl-30 lg:pl-0", titleSpacing[menuLevel])}>{title}</span>
         </button>
       )}
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-698 | fixup about us menu item display

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to the [preview site](https://su-library-git-bug-sul23-698-nav-stanford-libraries.vercel.app/) on Firefox
4. Verify that the About Us doesn't break into two lines when changing the screen width
5. Review code


# Associated Issues and/or People
- SUL23-698 
