### PR TITLE
SUL23-748 | add catalog and articles searchwork options to hero search

### DIFF
--- a/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
+++ b/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
@@ -52,11 +52,15 @@ export const SulHomeBannerFormClient = () => {
         </label>
         <select
           id={`${inputId}-action`}
-          className="h-40 w-full border-0 bg-none text-16 font-semibold hover:cursor-pointer md:w-auto md:min-w-[15rem] md:text-20 xl:text-22"
+          className="h-40 w-full border-0 bg-none text-16 font-semibold leading-normal hover:cursor-pointer md:w-auto md:min-w-[15rem] md:text-20 xl:text-22"
           onChange={e => setFormAction(e.target.value)}
           value={formAction}
         >
-          <option value="/all">All resources</option>
+          <option value="/all">All library resources</option>
+          <option value="/?q=climate+change">Catalog</option>
+          <option value="/articles?q=climate+change&f[eds_search_limiters_facet][]=Direct+access+to+full+text">
+            Articles+
+          </option>
           <option value="/search">This site</option>
         </select>
         <PlayIcon className="pointer-events-none absolute right-0 top-1/2 z-10 -translate-y-1/2 rotate-90" width={20} />

--- a/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
+++ b/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
@@ -25,6 +25,7 @@ export const SulHomeBannerRandomClient = ({children, ...props}: Props) => {
 }
 
 export const SulHomeBannerFormClient = () => {
+  const [query, setQuery] = useState("")
   const [formAction, setFormAction] = useState("/all")
   const inputId = useId()
   return (
@@ -42,6 +43,7 @@ export const SulHomeBannerFormClient = () => {
           name="q"
           id={inputId}
           placeholder="Search for books, articles, and more"
+          onChange={e => setQuery(e.target.value)}
         />
       </div>
       <div className="hidden h-50 w-[.5px] shrink-0 bg-black xs:block" />
@@ -58,7 +60,9 @@ export const SulHomeBannerFormClient = () => {
         >
           <option value="/all">All library resources</option>
           <option value="https://searchworks.stanford.edu/">Catalog</option>
-          <option value="https://searchworks.stanford.edu/articles?q=climate+change&f[eds_search_limiters_facet][]=Direct+access+to+full+text">
+          <option
+            value={`https://searchworks.stanford.edu/articles?q={${encodeURIComponent(query)}}&f[eds_search_limiters_facet][]=Direct+access+to+full+text`}
+          >
             Articles+
           </option>
           <option value="/search">This site</option>

--- a/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
+++ b/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
@@ -25,9 +25,10 @@ export const SulHomeBannerRandomClient = ({children, ...props}: Props) => {
 }
 
 export const SulHomeBannerFormClient = () => {
-  const [query, setQuery] = useState("")
   const [formAction, setFormAction] = useState("/all")
   const inputId = useId()
+
+  console.log("form action:", formAction)
   return (
     <form
       action={formAction}
@@ -43,7 +44,6 @@ export const SulHomeBannerFormClient = () => {
           name="q"
           id={inputId}
           placeholder="Search for books, articles, and more"
-          onChange={e => setQuery(e.target.value)}
         />
       </div>
       <div className="hidden h-50 w-[.5px] shrink-0 bg-black xs:block" />
@@ -60,14 +60,13 @@ export const SulHomeBannerFormClient = () => {
         >
           <option value="/all">All library resources</option>
           <option value="https://searchworks.stanford.edu/">Catalog</option>
-          <option
-            value={`https://searchworks.stanford.edu/articles?q={${encodeURIComponent(query)}}&f[eds_search_limiters_facet][]=Direct+access+to+full+text`}
-          >
-            Articles+
-          </option>
+          <option value={`https://searchworks.stanford.edu/articles`}>Articles+</option>
           <option value="/search">This site</option>
         </select>
         <PlayIcon className="pointer-events-none absolute right-0 top-1/2 z-10 -translate-y-1/2 rotate-90" width={20} />
+        {formAction === "https://searchworks.stanford.edu/articles" && (
+          <input type="hidden" name="f[eds_search_limiters_facet][]" value="Direct access to full text" />
+        )}
       </div>
       <button
         className="button relative m-0 block h-40 w-40 shrink-0 p-0 md:h-auto md:w-auto md:px-20 md:py-10"

--- a/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
+++ b/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
@@ -27,8 +27,6 @@ export const SulHomeBannerRandomClient = ({children, ...props}: Props) => {
 export const SulHomeBannerFormClient = () => {
   const [formAction, setFormAction] = useState("/all")
   const inputId = useId()
-
-  console.log("form action:", formAction)
   return (
     <form
       action={formAction}

--- a/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
+++ b/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
@@ -57,8 +57,8 @@ export const SulHomeBannerFormClient = () => {
           value={formAction}
         >
           <option value="/all">All library resources</option>
-          <option value="/catalog">Catalog</option>
-          <option value="/articles?q=climate+change&f[eds_search_limiters_facet][]=Direct+access+to+full+text">
+          <option value="https://searchworks.stanford.edu/">Catalog</option>
+          <option value="https://searchworks.stanford.edu/articles?q=climate+change&f[eds_search_limiters_facet][]=Direct+access+to+full+text">
             Articles+
           </option>
           <option value="/search">This site</option>

--- a/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
+++ b/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
@@ -57,7 +57,7 @@ export const SulHomeBannerFormClient = () => {
           value={formAction}
         >
           <option value="/all">All library resources</option>
-          <option value="/?q=climate+change">Catalog</option>
+          <option value="/catalog">Catalog</option>
           <option value="/articles?q=climate+change&f[eds_search_limiters_facet][]=Direct+access+to+full+text">
             Articles+
           </option>

--- a/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
+++ b/src/components/paragraph/sul-home-banner/sul-home-banner.client.tsx
@@ -58,7 +58,7 @@ export const SulHomeBannerFormClient = () => {
         >
           <option value="/all">All library resources</option>
           <option value="https://searchworks.stanford.edu/">Catalog</option>
-          <option value={`https://searchworks.stanford.edu/articles`}>Articles+</option>
+          <option value="https://searchworks.stanford.edu/articles">Articles+</option>
           <option value="/search">This site</option>
         </select>
         <PlayIcon className="pointer-events-none absolute right-0 top-1/2 z-10 -translate-y-1/2 rotate-90" width={20} />

--- a/vercel.json
+++ b/vercel.json
@@ -62,11 +62,11 @@
     },
     {
       "source": "/articles",
-      "destination": "https://searchworks.stanford.edu/"
+      "destination": "https://searchworks.stanford.edu/articles"
     },
     {
       "source": "/articles/:path*",
-      "destination": "https://searchworks.stanford.edu/articles:path*"
+      "destination": "https://searchworks.stanford.edu/articles/:path*"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -51,22 +51,6 @@
     {
       "source": "/assets/:path*",
       "destination": "https://discover.stanford.edu/assets/:path*"
-    },
-    {
-      "source": "/catalog",
-      "destination": "https://searchworks.stanford.edu/"
-    },
-    {
-      "source": "/catalog/:path*",
-      "destination": "https://searchworks.stanford.edu/:path*"
-    },
-    {
-      "source": "/articles",
-      "destination": "https://searchworks.stanford.edu/articles"
-    },
-    {
-      "source": "/articles/:path*",
-      "destination": "https://searchworks.stanford.edu/articles/:path*"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,22 @@
     {
       "source": "/assets/:path*",
       "destination": "https://discover.stanford.edu/assets/:path*"
+    },
+    {
+      "source": "/catalog",
+      "destination": "https://searchworks.stanford.edu/"
+    },
+    {
+      "source": "/catalog/:path*",
+      "destination": "https://searchworks.stanford.edu/:path*"
+    },
+    {
+      "source": "/articles",
+      "destination": "https://searchworks.stanford.edu/"
+    },
+    {
+      "source": "/articles/:path*",
+      "destination": "https://searchworks.stanford.edu/articles:path*"
     }
   ]
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-748 | add catalog and articles searchwork options to hero search

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to https://su-library-git-feature-sul23-748-stanford-libraries.vercel.app/
2. Verify that when searching for Catalog or Article+, you are redirected to searchworks
3. Review code

# Associated Issues and/or People
- SUL23-748 | add catalog and articles searchwork options to hero search