### PR TITLE
SUL23-765 | ensure that text breaks into new line when it exceeds nest menu item width

### DIFF
--- a/src/components/menu/main-menu.tsx
+++ b/src/components/menu/main-menu.tsx
@@ -220,7 +220,7 @@ const MenuItem = ({
           )}
           aria-current={activeTrail.at(-1) === id ? "page" : undefined}
         >
-          <div className={twMerge("shrink-0 pl-30 lg:pl-0", titleSpacing[menuLevel])}>{title}</div>
+          <div className={twMerge("w-full shrink-0 pl-30 lg:pl-0", titleSpacing[menuLevel])}>{title}</div>
         </Link>
       )}
 
@@ -234,7 +234,7 @@ const MenuItem = ({
           onClick={toggleSubmenu}
           aria-expanded={submenuOpen ? "true" : "false"}
         >
-          <span className={twMerge("shrink-0 pl-30 lg:pl-0", titleSpacing[menuLevel])}>{title}</span>
+          <span className={twMerge("w-full shrink-0 pl-30 lg:pl-0", titleSpacing[menuLevel])}>{title}</span>
         </button>
       )}
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-765 | ensure that text breaks into new line when it exceeds nest menu item width

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to https://su-library-git-bug-sul23-765-stanford-libraries.vercel.app/
2. Verify that the secondary menu link under `About us` > `Support the Library...` link appears on two lines
3. Review code

# Associated Issues and/or People
- SUL23-765