### PR TITLE
SUL23-773 SUL23-774 | resolve media image center bug and site improve overflow hidden issue

### DIFF
--- a/src/components/patterns/card.tsx
+++ b/src/components/patterns/card.tsx
@@ -61,7 +61,7 @@ const Card = ({
     >
       {image && (
         <div className="relative h-fit w-full">
-          <div className="relative aspect-[16/9] overflow-hidden" aria-hidden="true">
+          <div className="relative aspect-[16/9]" aria-hidden="true">
             {image}
           </div>
           {caption && (

--- a/src/lib/format-html.tsx
+++ b/src/lib/format-html.tsx
@@ -75,6 +75,7 @@ const options: HTMLReactParserOptions = {
           nodeProps.className = twMerge(
             nodeProps.className,
             "table mb-20",
+            nodeProps.className.includes("center") && "*:mx-auto",
             !nodeProps.className.includes("float") && "w-full"
           )
           delete nodeProps.role


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-773 SUL23-774 | resolve media image center bug and site improve overflow hidden issue

# Review By (Date)
- EOD Monday 04/28/25

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to homepage preview: https://su-library-git-bug-sul23-773-774-stanford-libraries.vercel.app/
2. Verify that the cards appear the same as production (I removed `overflow-hidden` for SI purposes; it seems like that style has no impact on the cards. 🤔 )
3. Navigate to a news page with an image: https://su-library-git-bug-sul23-773-774-stanford-libraries.vercel.app/news/david-harris-archive
4. Verify that the bottom image is centered (compared to prod: https://library.stanford.edu/news/david-harris-archive)
5. Review code 🌱 

# Associated Issues and/or People
- SUL23-773
- SUL23-774