### PR TITLE
SUL23-769 | fixup conflicting wysiwyg styles

### DIFF
--- a/src/lib/format-html.tsx
+++ b/src/lib/format-html.tsx
@@ -110,9 +110,8 @@ const options: HTMLReactParserOptions = {
           return <NodeName {...nodeProps}>{domToReact(domNode.children as DOMNode[], options)}</NodeName>
 
         case "p":
-          nodeProps.className += " max-w-[100ch] text-16 sm:text-18 [&_li]:text-16 [&_li]:sm:text-18"
+          nodeProps.className += " max-w-[100ch]"
         case "li":
-          nodeProps.className += " text-16 sm:text-18"
         case "h1":
         case "h2":
         case "h3":

--- a/src/styles/tailwind/plugins/base/base.js
+++ b/src/styles/tailwind/plugins/base/base.js
@@ -50,6 +50,12 @@ module.exports = function () {
         fontSize: '2.4rem',
         fontWeight: 'semibold',
       },
+      'p, li': {
+        fontSize: '1.6rem',
+        '@screen sm': {
+          fontSize: '1.8rem',
+        },
+      }
     });
   };
 };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-769 | fixup conflicting wysiwyg styles
(This resolves the `text-16 sm:text-18` typography overriding the styles)

# Review By (Date)
- When possible


# Review Tasks

## Setup tasks and/or behavior to test

1. Review code
2. Navigate to http://su-library-git-bug-sul23-769-stanford-libraries.vercel.app/research-support/data-support-and-services
3. Verify that the intro/sub title style appears
4. Bonus: Pull code down to local and create a page with all the text styles

# Associated Issues and/or People
- SUL23-769