### PR TITLE
SUL23-793 SUL23-794 SUL23-795 | rework page header for basic, person, and news content types

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -10,6 +10,7 @@ import FlushCache from "@/components/patterns/elements/flush-cache"
 import OnThisPage from "@/components/patterns/on-this-page"
 import DrupalLink from "@/components/patterns/elements/drupal-link"
 import {getPathFromContext, PageProps, Slug} from "@/lib/drupal/utils"
+import RosetteIcon from "@/components/patterns/icons/RosetteIcon"
 
 export const revalidate = false
 export const dynamic = "force-static"
@@ -67,8 +68,9 @@ const NodePage = async (props: PageProps & {previewMode?: true}) => {
           <InternalHeaderBanner>
             <h1
               id={entity.id}
-              className="relative mx-auto mb-50 mt-80 w-full max-w-[calc(100vw-10rem)] p-0 text-white md:mt-100 md:max-w-[calc(100vw-20rem)] 3xl:max-w-[calc(1500px-20rem)]"
+              className="relative mx-auto mb-10 mt-48 flex w-full max-w-[calc(100vw-10rem)] flex-row gap-20 p-0 md:max-w-[calc(100vw-20rem)] 3xl:max-w-[calc(1500px-20rem)]"
             >
+              {entity.__typename === "NodeStanfordPage" && <RosetteIcon width={60} height={60} />}
               {entity.title}
             </h1>
           </InternalHeaderBanner>

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -9,8 +9,9 @@ import EditorAlertBanner from "@/components/patterns/elements/editor-alert-banne
 import FlushCache from "@/components/patterns/elements/flush-cache"
 import OnThisPage from "@/components/patterns/on-this-page"
 import DrupalLink from "@/components/patterns/elements/drupal-link"
-import {getPathFromContext, PageProps, Slug} from "@/lib/drupal/utils"
+import {buildUrl, getPathFromContext, PageProps, Slug} from "@/lib/drupal/utils"
 import RosetteIcon from "@/components/patterns/icons/RosetteIcon"
+import Image from "next/image"
 
 export const revalidate = false
 export const dynamic = "force-static"
@@ -46,25 +47,65 @@ const NodePage = async (props: PageProps & {previewMode?: true}) => {
 
         {entity.__typename === "NodeStanfordNews" && (
           <InternalHeaderBanner>
-            <div className="mx-auto mb-50 mt-80 flex w-full max-w-[calc(100vw-10rem)] flex-col p-0 md:mt-100 md:max-w-[calc(100vw-20rem)] 3xl:max-w-[calc(1500px-20rem)]">
-              <h1 id={entity.id} className="order-2 text-white">
+            <div className="mx-auto mb-65 mt-48 flex w-full max-w-[calc(100vw-10rem)] flex-col p-0 md:max-w-[calc(100vw-20rem)] 3xl:max-w-[calc(1500px-20rem)]">
+              <h1 id={entity.id} className="order-2 mb-0">
                 {entity.title}
               </h1>
 
               {entity.suNewsTopics && (
-                <div className="order-1 mb-20">
+                <div className="order-1 mb-1">
                   {entity.suNewsTopics.slice(0, 1).map(topic => (
-                    <span key={topic.id} className="font-semibold text-illuminating-dark">
+                    <span key={topic.id} className="text-22 font-semibold uppercase text-cardinal-red">
                       {topic.name}
                     </span>
                   ))}
+                </div>
+              )}
+              {entity.suNewsDek && <p className="order-3 mb-0 text-23 leading md:text-28">{entity.suNewsDek}</p>}
+            </div>
+          </InternalHeaderBanner>
+        )}
+
+        {entity.__typename === "NodeStanfordPerson" && (
+          <InternalHeaderBanner>
+            <div className="mx-auto mb-40 mt-48 flex w-full max-w-[calc(100vw-10rem)] flex-col items-center gap-32 p-0 md:mb-10 md:max-w-[calc(100vw-20rem)] md:flex-row 3xl:max-w-[calc(1500px-20rem)]">
+              <div className="order-2 flex flex-col">
+                <h1 id={entity.id} className="mb-0">
+                  {entity.title}
+                </h1>
+                <div>
+                  {(entity.suPersonFullTitle || entity.suPersonShortTitle) && (
+                    <div className="text-23 md:text-28">{entity.suPersonFullTitle || entity.suPersonShortTitle}</div>
+                  )}
+
+                  {entity.suPersonPronouns && (
+                    <div className="text-23 md:text-28">Pronouns: {entity.suPersonPronouns}</div>
+                  )}
+                </div>
+              </div>
+
+              {entity.suPersonPhoto && (
+                <div className="order-1">
+                  <div className="relative aspect-[1/1] w-220">
+                    <Image
+                      src={buildUrl(entity.suPersonPhoto?.mediaImage.url).toString()}
+                      alt=""
+                      className="rounded-full object-cover"
+                      fill
+                      sizes="500px"
+                    />
+                  </div>
                 </div>
               )}
             </div>
           </InternalHeaderBanner>
         )}
 
-        {!(entity.__typename === "NodeSulLibrary" || entity.__typename === "NodeStanfordNews") && (
+        {!(
+          entity.__typename === "NodeSulLibrary" ||
+          entity.__typename === "NodeStanfordNews" ||
+          entity.__typename === "NodeStanfordPerson"
+        ) && (
           <InternalHeaderBanner>
             <h1
               id={entity.id}

--- a/src/components/node/stanford-news/page-display.tsx
+++ b/src/components/node/stanford-news/page-display.tsx
@@ -30,15 +30,14 @@ const StanfordNews = async ({node, ...props}: {node: NodeStanfordNews}) => {
   const encodeTitle = encodeURIComponent(node.title)
 
   return (
-    <article {...props} className="centered mt-50">
+    <article {...props} className="centered">
       <StanfordNewsMetadata node={node} />
-      <div className="centered mb-100 2xl:w-2/3">
-        {node.suNewsDek && <p className="rs-mb-1 text-22 leading">{node.suNewsDek}</p>}
-        <div className="md:flex">
+      <div className="centered mb-40 2xl:w-2/3">
+        <div className="mx-auto w-fit gap-16 md:flex">
           <div className="flex md:order-last">
             {!node.suNewsHideSocial && (
-              <ul className="list-unstyled mt-[-3px] flex md:pl-[10px]">
-                <li className="mr-1em">
+              <ul className="list-unstyled flex flex-row gap-[0.8rem]">
+                <li>
                   <NewsSocialLink
                     className="text-black transition-colors hocus:text-digital-blue"
                     prefix="http://www.facebook.com/sharer.php?u="
@@ -48,7 +47,7 @@ const StanfordNews = async ({node, ...props}: {node: NodeStanfordNews}) => {
                     <FacebookIcon />
                   </NewsSocialLink>
                 </li>
-                <li className="mr-1em">
+                <li>
                   <NewsSocialLink
                     className="text-black transition-colors hocus:text-digital-blue"
                     prefix="https://twitter.com/intent/tweet?url="
@@ -58,7 +57,7 @@ const StanfordNews = async ({node, ...props}: {node: NodeStanfordNews}) => {
                     <TwitterIcon />
                   </NewsSocialLink>
                 </li>
-                <li className="mr-1em">
+                <li>
                   <NewsSocialLink
                     className="text-black transition-colors hocus:text-digital-blue"
                     prefix="https://www.linkedin.com/shareArticle?mini=true&url="
@@ -68,7 +67,7 @@ const StanfordNews = async ({node, ...props}: {node: NodeStanfordNews}) => {
                     <LinkedInIcon />
                   </NewsSocialLink>
                 </li>
-                <li className="mr-1em">
+                <li>
                   <NewsSocialLink
                     className="text-black transition-colors hocus:text-digital-blue"
                     prefix={`mailto:?subject=${encodeTitle}&body=`}
@@ -77,7 +76,7 @@ const StanfordNews = async ({node, ...props}: {node: NodeStanfordNews}) => {
                     <EnvelopeIcon title="Email" width={28} />
                   </NewsSocialLink>
                 </li>
-                <li className="mr-1em">
+                <li>
                   <NewsPrintButton />
                 </li>
               </ul>
@@ -89,11 +88,11 @@ const StanfordNews = async ({node, ...props}: {node: NodeStanfordNews}) => {
           </div>
         </div>
       </div>
-      <hr className="mx-auto mb-100 w-1/2 text-black-40" />
+      <hr className="mx-auto mb-40 w-1/2 text-black-40" />
 
       {imageUrl && (
-        <figure className="mb-100 table w-full">
-          <span className="relative mx-auto block aspect-[16/9] lg:w-10/12">
+        <figure className="mb-40 table w-full">
+          <span className="relative mx-auto block aspect-[16/9] lg:w-800">
             <Image className="object-cover" src={buildUrl(imageUrl).toString()} alt={imageAlt || ""} fill />
           </span>
           {node.suNewsBannerMediaCaption && (
@@ -118,7 +117,7 @@ const StanfordNews = async ({node, ...props}: {node: NodeStanfordNews}) => {
       )}
 
       {node.suNewsComponents && (
-        <div className="centered 2xl:w-2/3">
+        <div className="w-full lg:children:max-w-1000">
           {node.suNewsComponents.map(paragraph => (
             <Paragraph key={paragraph.id} paragraph={paragraph} />
           ))}

--- a/src/components/node/stanford-person/page-display.tsx
+++ b/src/components/node/stanford-person/page-display.tsx
@@ -1,16 +1,15 @@
-import Image from "next/image"
 import formatHtml from "@/lib/format-html"
 import {DrupalLinkButton} from "@/components/patterns/link"
-import {EnvelopeIcon, LinkIcon, MapIcon, PhoneIcon} from "@heroicons/react/20/solid"
+import {EnvelopeIcon, PhoneIcon, MapIcon} from "@heroicons/react/24/outline"
 import Link from "@/components/patterns/elements/drupal-link"
 import LibCal from "@/components/node/stanford-person/libcal"
 import LibGuides from "@/components/node/stanford-person/libguide"
 import fetchLibGuides from "@/lib/libguides"
 import EmailLink from "@/components/patterns/elements/email-link"
-import {buildUrl} from "@/lib/drupal/utils"
 import {NodeStanfordPerson} from "@/lib/gql/__generated__/drupal.d"
 import Paragraph from "@/components/paragraph"
 import StanfordPersonMetadata from "@/components/node/stanford-person/stanford-person-metadata"
+import NumberLink from "@/components/patterns/elements/number-link"
 
 const StanfordPerson = async ({node, ...props}: {node: NodeStanfordPerson}) => {
   const libGuides = node.sulPersonLibguideId
@@ -19,7 +18,6 @@ const StanfordPerson = async ({node, ...props}: {node: NodeStanfordPerson}) => {
         cacheTags: [`paths:${node.path || "#"}`],
       })
     : []
-  const imageUrl = node.suPersonPhoto?.mediaImage.url
 
   const lastUpdated = new Date(node.changed.time as string).toLocaleDateString("en-us", {
     month: "long",
@@ -31,32 +29,12 @@ const StanfordPerson = async ({node, ...props}: {node: NodeStanfordPerson}) => {
   return (
     <article {...props}>
       <StanfordPersonMetadata node={node} />
-      <div className="no-wrap rs-mb-5 mt-50 sm:flex">
-        {imageUrl && (
-          <div className="rs-mb-1 rs-mr-4 sm:mb-[0rem]">
-            <div className="relative h-[220px] w-[220px] overflow-hidden rounded-full">
-              <Image className="object-cover" src={buildUrl(imageUrl).toString()} alt="" fill sizes="500px" />
-            </div>
-          </div>
-        )}
-
-        <div className="flex flex-col justify-center gap-2xl">
-          <div>
-            {(node.suPersonFullTitle || node.suPersonShortTitle) && (
-              <div className="type-0 leading">{node.suPersonFullTitle || node.suPersonShortTitle}</div>
-            )}
-
-            {node.suPersonPronouns && <div className="type-0 leading">Pronouns: {node.suPersonPronouns}</div>}
-          </div>
-
-          {node.sulPersonLibcalId && <LibCal libcalId={node.sulPersonLibcalId} srText={node.title} />}
-        </div>
-      </div>
-
       <div className="grid gap-2xl md:grid-cols-6">
-        <div className="col-span-4">
-          {node.body && (
-            <div className="rs-mt-6 rs-mb-7 type-1 sm:rs-mt-0 md:w-10/12">{formatHtml(node.body.processed)}</div>
+        <div className="flex flex-col gap-40 md:col-span-4">
+          {node.body && <div className="text-20 last:children:mb-0">{formatHtml(node.body.processed)}</div>}
+
+          {node.suPersonProfileLink?.url && (
+            <DrupalLinkButton href={node.suPersonProfileLink.url}>{node.suPersonProfileLink.title}</DrupalLinkButton>
           )}
 
           {node.suPersonComponents && (
@@ -70,34 +48,36 @@ const StanfordPerson = async ({node, ...props}: {node: NodeStanfordPerson}) => {
           {libGuides.length > 0 && <LibGuides guides={libGuides} className="mb-50 space-y-40" />}
 
           {node.suPersonEducation && (
-            <div className="rs-mb-7">
-              <h2 className="type-1">Education</h2>
-              {node.suPersonEducation.map((education, index) => (
-                <div key={`person-education-${index}`} className="rs-mb-0">
-                  {education}
-                </div>
-              ))}
+            <div>
+              <h2 className="mb-16">Education</h2>
+              <ul className="list-none p-0">
+                {node.suPersonEducation.map((education, index) => (
+                  <li key={`person-education-${index}`} className="rs-mb-0">
+                    {education}
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
 
           {node.suPersonResearch && (
-            <div className="rs-mb-7">
-              <h2 className="type-1">Expertise</h2>
-              <div className="grid-cols-2 md:grid">
+            <div>
+              <h2 className="mb-16">Expertise</h2>
+              <ul className="list-none p-0">
                 {node.suPersonResearch.map((interest, index) => (
-                  <div key={`research-${index}`} className="rs-mb-1">
+                  <li key={`research-${index}`} className="rs-mb-1">
                     {formatHtml(interest.processed)}
-                  </div>
+                  </li>
                 ))}
-              </div>
+              </ul>
             </div>
           )}
 
-          {node.suPersonResearchInterests && <div className="rs-mb-7">{node.suPersonResearchInterests}</div>}
+          {node.suPersonResearchInterests && <div>{node.suPersonResearchInterests}</div>}
 
           {node.suPersonAffiliations && (
-            <div className="rs-mb-7">
-              <h2 className="type-1">Stanford Affiliations</h2>
+            <div>
+              <h2 className="mb-16">Stanford Affiliations</h2>
               {node.suPersonAffiliations.map((affiliation, index) => {
                 if (!affiliation.url) return
                 return (
@@ -110,64 +90,67 @@ const StanfordPerson = async ({node, ...props}: {node: NodeStanfordPerson}) => {
           )}
         </div>
 
-        <div className="col-span-2">
-          <div className="rs-mb-7">
-            {(node.suPersonTelephone ||
-              node.suPersonMobilePhone ||
-              node.suPersonFax ||
-              node.suPersonMailCode ||
-              node.suPersonEmail) && (
-              <>
-                <div className="relative mb-4 mt-40 flex flex-row items-start md:mt-20">
-                  <PhoneIcon title="Phone" width={26} className="mr-3 md:absolute md:left-[-32px] md:mr-0" />
-                  <h2 className="type-0">Contact</h2>
-                </div>
-                <ul className="list-none p-0 children:mb-0">
-                  {node.suPersonTelephone && <li>p {node.suPersonTelephone}</li>}
-                  {node.suPersonMobilePhone && <li>m {node.suPersonMobilePhone}</li>}
-                  {node.suPersonFax && <li>f {node.suPersonFax}</li>}
-                  {node.suPersonMailCode && <li>Mail Code: {node.suPersonMailCode}</li>}
-                  {node.suPersonEmail && (
-                    <li>
-                      <EmailLink className="break-words" email={node.suPersonEmail} />
-                      <EnvelopeIcon title="Email" width={20} className="ml-4 inline-block text-digital-blue" />
-                    </li>
-                  )}
-                </ul>
-              </>
-            )}
-          </div>
-
-          <div className="rs-mb-7 children:leading">
-            {(node.suPersonLocationName || node.suPersonLocationAddress || node.suPersonMapUrl) && (
-              <>
-                <div className="relative mb-4 mt-40 flex flex-row items-start md:mt-20">
-                  <MapIcon title="Location" width={26} className="mr-3 md:absolute md:left-[-32px] md:mr-0" />
-                  <h2 className="type-0">Location</h2>
-                </div>
-
-                {node.suPersonLocationName && <div>{node.suPersonLocationName}</div>}
-
-                {node.suPersonLocationAddress && (
-                  <div className="children:mb-0">{formatHtml(node.suPersonLocationAddress.processed)}</div>
+        <div className="flex h-fit flex-col justify-between gap-24 border border-black-10 p-32 shadow-lg md:col-span-2">
+          {(node.suPersonTelephone ||
+            node.suPersonMobilePhone ||
+            node.suPersonFax ||
+            node.suPersonMailCode ||
+            node.suPersonEmail) && (
+            <div>
+              <h2 className="text-24">Contact</h2>
+              <ul className="list-none p-0 children:mb-[0.4rem] last:children:mb-0">
+                {node.suPersonTelephone && (
+                  <li>
+                    <PhoneIcon title="Phone" width={24} className="mr-4 inline-block text-digital-blue" />p{" "}
+                    <NumberLink tel={node.suPersonTelephone} />
+                  </li>
                 )}
-
-                {node.suPersonMapUrl?.url && (
-                  <div>
-                    Map URL: <Link href={node.suPersonMapUrl.url}>{node.suPersonMapUrl.url}</Link>
-                  </div>
+                {node.suPersonMobilePhone && (
+                  <li>
+                    <PhoneIcon title="Phone" width={24} className="mr-4 inline-block text-digital-blue" /> m{" "}
+                    <NumberLink tel={node.suPersonMobilePhone} />
+                  </li>
                 )}
-              </>
-            )}
-          </div>
+                {node.suPersonFax && (
+                  <li>
+                    <PhoneIcon title="Phone" width={24} className="mr-4 inline-block text-digital-blue" />f{" "}
+                    <NumberLink tel={node.suPersonFax} />
+                  </li>
+                )}
+                {node.suPersonEmail && (
+                  <li>
+                    <EnvelopeIcon title="Email" width={20} className="mr-4 inline-block text-digital-blue" />
+                    <EmailLink className="break-words" email={node.suPersonEmail} />
+                  </li>
+                )}
+                {node.suPersonMailCode && <li>Mail Code: {node.suPersonMailCode}</li>}
+              </ul>
+            </div>
+          )}
+
+          {(node.suPersonLocationName || node.suPersonLocationAddress || node.suPersonMapUrl) && (
+            <div className="children:mb-[0.4rem] last:children:mb-0">
+              <h2 className="text-24">Location</h2>
+
+              {node.suPersonLocationName && <div>{node.suPersonLocationName}</div>}
+
+              {node.suPersonLocationAddress && (
+                <div className="children:mb-0">{formatHtml(node.suPersonLocationAddress.processed)}</div>
+              )}
+
+              {node.suPersonMapUrl?.url && (
+                <div>
+                  <MapIcon title="Location" width={26} className="mr-4 inline-block text-digital-blue" />
+                  <Link href={node.suPersonMapUrl.url}>Map</Link>
+                </div>
+              )}
+            </div>
+          )}
 
           {node.suPersonLinks && (
-            <div className="rs-mb-4">
-              <div className="relative mb-4 mt-40 flex flex-row items-start md:mt-20">
-                <LinkIcon title="Link" width={26} className="mr-3 md:absolute md:left-[-32px] md:mr-0" />
-                <h2 className="type-0">Links</h2>
-              </div>
-              <ul>
+            <div>
+              <h2 className="text-24">Links</h2>
+              <ul className="list-none p-0 children:mb-[0.4rem] last:children:mb-0">
                 {node.suPersonLinks.map((link, index) => {
                   if (!link.url) return
                   return (
@@ -181,15 +164,10 @@ const StanfordPerson = async ({node, ...props}: {node: NodeStanfordPerson}) => {
               </ul>
             </div>
           )}
-
-          {node.suPersonProfileLink?.url && (
-            <DrupalLinkButton className="rs-mb-4" href={node.suPersonProfileLink.url}>
-              {node.suPersonProfileLink.title}
-            </DrupalLinkButton>
-          )}
+          {node.sulPersonLibcalId && <LibCal libcalId={node.sulPersonLibcalId} srText={node.title} />}
         </div>
       </div>
-      <div className="rs-pb-4 centered">Last updated {lastUpdated}</div>
+      <div className="rs-mb-0 rs-mt-4 centered">Last updated {lastUpdated}</div>
     </article>
   )
 }

--- a/src/components/node/stanford-person/page-display.tsx
+++ b/src/components/node/stanford-person/page-display.tsx
@@ -100,26 +100,26 @@ const StanfordPerson = async ({node, ...props}: {node: NodeStanfordPerson}) => {
               <h2 className="text-24">Contact</h2>
               <ul className="list-none p-0 children:mb-[0.4rem] last:children:mb-0">
                 {node.suPersonTelephone && (
-                  <li>
-                    <PhoneIcon title="Phone" width={24} className="mr-4 inline-block text-digital-blue" />p{" "}
+                  <li className="flex flex-row items-center">
+                    <PhoneIcon title="Phone" width={24} className="mr-4 text-digital-blue" />p{" "}
                     <NumberLink tel={node.suPersonTelephone} />
                   </li>
                 )}
                 {node.suPersonMobilePhone && (
-                  <li>
-                    <PhoneIcon title="Phone" width={24} className="mr-4 inline-block text-digital-blue" /> m{" "}
+                  <li className="flex flex-row items-center">
+                    <PhoneIcon title="Phone" width={24} className="mr-4 text-digital-blue" /> m{" "}
                     <NumberLink tel={node.suPersonMobilePhone} />
                   </li>
                 )}
                 {node.suPersonFax && (
-                  <li>
-                    <PhoneIcon title="Phone" width={24} className="mr-4 inline-block text-digital-blue" />f{" "}
+                  <li className="flex flex-row items-center">
+                    <PhoneIcon title="Phone" width={24} className="mr-4 text-digital-blue" />f{" "}
                     <NumberLink tel={node.suPersonFax} />
                   </li>
                 )}
                 {node.suPersonEmail && (
-                  <li>
-                    <EnvelopeIcon title="Email" width={20} className="mr-4 inline-block text-digital-blue" />
+                  <li className="flex flex-row items-center">
+                    <EnvelopeIcon title="Email" width={24} className="mr-4 text-digital-blue" />
                     <EmailLink className="break-words" email={node.suPersonEmail} />
                   </li>
                 )}
@@ -132,16 +132,18 @@ const StanfordPerson = async ({node, ...props}: {node: NodeStanfordPerson}) => {
             <div className="children:mb-[0.4rem] last:children:mb-0">
               <h2 className="text-24">Location</h2>
 
-              {node.suPersonLocationName && <div>{node.suPersonLocationName}</div>}
+              {node.suPersonLocationName && <div className="text-16 md:text-18">{node.suPersonLocationName}</div>}
 
               {node.suPersonLocationAddress && (
                 <div className="children:mb-0">{formatHtml(node.suPersonLocationAddress.processed)}</div>
               )}
 
               {node.suPersonMapUrl?.url && (
-                <div>
-                  <MapIcon title="Location" width={26} className="mr-4 inline-block text-digital-blue" />
-                  <Link href={node.suPersonMapUrl.url}>Map</Link>
+                <div className="flex flex-row items-center">
+                  <MapIcon title="Location" width={24} className="mr-4 text-digital-blue" />
+                  <Link href={node.suPersonMapUrl.url} className="text-16 md:text-18">
+                    Map
+                  </Link>
                 </div>
               )}
             </div>

--- a/src/components/patterns/elements/number-link.tsx
+++ b/src/components/patterns/elements/number-link.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import Obfuscate from "react-obfuscate"
+import {HTMLProps} from "react"
+
+const NumberLink = ({tel}: {tel: string} & HTMLProps<HTMLAnchorElement>) => {
+  return <Obfuscate tel={tel} />
+}
+export default NumberLink

--- a/src/components/patterns/internal-header-banner.tsx
+++ b/src/components/patterns/internal-header-banner.tsx
@@ -3,7 +3,7 @@ import {PropsWithChildren} from "react"
 
 const InternalHeaderBanner = ({children}: PropsWithChildren) => {
   return (
-    <header className="relative mb-50 overflow-auto border-t border-black-50 bg-fog-light">
+    <header className="relative mb-60 overflow-auto border-t border-black-50 bg-fog-light">
       <div className="relative z-[1]">{children}</div>
       <div className="relative">
         <Wave />

--- a/src/components/patterns/internal-header-banner.tsx
+++ b/src/components/patterns/internal-header-banner.tsx
@@ -3,17 +3,8 @@ import {PropsWithChildren} from "react"
 
 const InternalHeaderBanner = ({children}: PropsWithChildren) => {
   return (
-    <header className="relative mb-50 overflow-auto bg-black-true">
+    <header className="relative mb-50 overflow-auto border-t border-black-50 bg-fog-light">
       <div className="relative z-[1]">{children}</div>
-
-      <div className="absolute bottom-0 right-0 h-2/3 w-1/2 bg-right-bottom lg:bg-interior-header-sprinkles">
-        <div className="absolute h-full w-full bg-gradient-to-b from-black-true to-transparent">
-          <div className="absolute h-full w-full bg-gradient-to-r from-black-true to-transparent">
-            {/*Empty elements. They are absolute positioned to provide visual affects only.*/}
-          </div>
-        </div>
-      </div>
-
       <div className="relative">
         <Wave />
       </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- rework page header for basic, person, and news content types


# Review By (Date)
- EOD Thursday, 5/22

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to
2. Verify that the heading matches the [figma](https://www.figma.com/design/yr0Nd7t7qGW4S95OtSCqa3/Secondary-page---header-and-people?node-id=129-2529&t=7Alo5bi5HZgdeajt-1)
3. Navigate to https://su-library-git-feature-sul23-793-stanford-libraries.vercel.app/people/first-last
4. Verify that the heading and body content matches [figma](https://www.figma.com/design/yr0Nd7t7qGW4S95OtSCqa3/Secondary-page---header-and-people?node-id=127-2542&t=7Alo5bi5HZgdeajt-1). _Note:_ I plan to review certain fields that weren't account for in mocks with Darcy during our FE Sync on Friday
5. Navigate to https://su-library-git-feature-sul23-793-stanford-libraries.vercel.app/news/new-japanese-studies-librarian-katherine-matsuura
6. Verify that the heading and body content matches [figma](https://www.figma.com/design/yr0Nd7t7qGW4S95OtSCqa3/Secondary-page---header-and-people?node-id=127-2161&t=jesSv98QZxoN5XzO-1)
7. Review code 👾 

# Associated Issues and/or People
- SUL23-793
- SUL23-794
- SUL23-795