### PR TITLE
SUL23-788 | prevent searchworks catalog link from line break

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -31,7 +31,7 @@ const Header = async () => {
             </div>
             <nav className="hidden lg:block" aria-label="User links">
               <ul className="list-unstyled flex items-baseline gap-24">
-                <li className="flex items-start">
+                <li className="flex shrink-0 items-start">
                   <Link className="text-16 font-normal text-black" href="https://searchworks.stanford.edu/">
                     SearchWorks Catalog
                   </Link>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-788 | prevent searchworks catalog link from line break

# Review By (Date)
- EOD Thursday, 05/22

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to preview
2. Verify that SearchWorks Catalog link doesn't break into two lines
3. Review code 🌱 

# Associated Issues and/or People
- SUL23-788