### PR TITLE
SUL23-843 SUL23-844 | update homepage banner text overlay background opacity and fix focus state of cta

### DIFF
--- a/src/components/paragraph/sul-home-image/sul-home-image.tsx
+++ b/src/components/paragraph/sul-home-image/sul-home-image.tsx
@@ -23,7 +23,7 @@ const SulHomeImage = ({paragraph, ...props}: Props) => {
       </div>
       {paragraph.sulHomeImageCredits && (
         <div className="bottom-50 w-full md:absolute">
-          <div className="p-16 shadow-lg md:ml-auto md:w-fit md:max-w-[633px] md:bg-black md:bg-opacity-50 md:text-white md:shadow-none lg:p-24 xl:p-32">
+          <div className="p-16 shadow-lg md:ml-auto md:w-fit md:max-w-[633px] md:bg-black md:bg-opacity-70 md:text-white md:shadow-none lg:p-24 xl:p-32">
             {paragraph.sulHomeImageCredits?.processed && (
               <div className="font-sans *:mb-0 md:text-right [&_a]:md:text-white">
                 {formatHtml(paragraph.sulHomeImageCredits.processed)}

--- a/src/lib/format-html.tsx
+++ b/src/lib/format-html.tsx
@@ -68,7 +68,7 @@ const options: HTMLReactParserOptions = {
           }
 
           nodeProps.className = twMerge(
-            "hocus:underline transition-colors hover:text-brick-dark hover:bg-black-10 focus:bg-none focus:text-cardinal-red active:text-cardinal-red",
+            "hocus:underline transition-colors hocus:bg-black-10 focus:bg-none hocus:text-cardinal-red active:text-cardinal-red",
             nodeProps.className
           )
           return <a {...nodeProps}>{domToReact(domNode.children as DOMNode[], options)}</a>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-843 SUL23-844 | update homepage banner text overlay background opacity and fix focus state of cta

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to preview homepage
4. Verify that the banner text overlay opacity is 70 and the focus state of links has a white background
5. Review code

# Associated Issues and/or People
- SUL23-843
- SUL23-844