### PR TITLE
SUL23-1036: Fix for the single button with a background color

### DIFF
--- a/src/components/paragraph/sul-button.tsx
+++ b/src/components/paragraph/sul-button.tsx
@@ -18,7 +18,7 @@ type Props = HTMLAttributes<HTMLDivElement> & {
   fullWidth?: Maybe<boolean>
 }
 
-const SulButton = ({headerId, headline, link, styles, fullWidth = true, ...props}: Props) => {
+const SulButton = ({headerId, headline, link, styles, fullWidth, ...props}: Props) => {
   const ref = useRef<HTMLDivElement>(null)
   const isCentered = useIsCentered(ref)
 

--- a/src/components/paragraph/sul-button.tsx
+++ b/src/components/paragraph/sul-button.tsx
@@ -39,7 +39,7 @@ const SulButton = ({headerId, headline, link, styles, fullWidth = true, ...props
         "relative",
         clsx({
           "w-full": !fullWidth || !isCentered || isCtaVariant,
-          "full-screen": (fullWidth || isCentered) && !isCtaVariant,
+          "full-screen": fullWidth && isCentered && !isCtaVariant,
           centered: isCtaVariant,
         })
       )}
@@ -52,7 +52,7 @@ const SulButton = ({headerId, headline, link, styles, fullWidth = true, ...props
           clsx({
             "bg-black-true": isBlackBackground,
             "bg-black-10": !isBlackBackground,
-            "w-screen": (fullWidth || isCentered) && !isCtaVariant,
+            "w-screen": fullWidth && isCentered && !isCtaVariant,
             "h-fit w-fit rounded border-2 border-black-10 bg-fog-light px-10 py-6 lg:ml-auto": isCtaVariant,
           })
         )}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Fix flickering of CSS classes in SulButton component caused by unstable `isCentered` measurement creating a feedback loop with layout changes.

# Review By (Date)
- 8/3

# Criticality
- 4/10 - Affects visual presentation of buttons on pages with centered layouts; affects all pages using `SulButton` component but does not impact functionality

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Run `npm install` and `npm run dev`
3. Navigate to any page with a SulButton component (e.g., Library Hours widget)
4. https://su-library-git-sul23-1036-stanford-libraries.vercel.app/events-and-workshops
5. https://su-library-git-sul23-1036-stanford-libraries.vercel.app/preview/demo-style-guide-all-components (at bottom of page)
6. Open DevTools Inspector and watch the DOM for rapid class changes on the button wrapper
7. Observe console for repeated `SulButton fullWidth prop` log entries
8. Verify that:
   - Button renders without flickering
   - Black background maintains stable full-width appearance
   - No visual reflow occurs during initial render

## Front End Validation
- [ ] Visual inspection: Button renders stably without flickering
- [ ] DevTools: No rapid DOM class toggling observed
- [ ] Cross-browser testing: Verified on Chrome, Firefox, Safari (or QA request created)
- [ ] Automated accessibility: A11y scans performed or QA request created

## Backend / Functional Validation
### Code
- [ ] Follows naming conventions
- [ ] Change is minimal and focused on the issue
- [ ] No unnecessary refactoring included

### Code security
- [ ] No security implications

## General
- [ ] Only changes related to the flickering issue are included
- [ ] Approach addresses root cause (isCentered feedback loop) rather than symptoms

# Affected Projects or Products
- SulButton component impacts all pages using button sections with centered layouts

# Associated Issues and/or People
- **Bug:** SulButton Classes Flickering on Page Load
- **Root Cause:** `useIsCentered` hook creates feedback loop - layout classes change element width, which recalculates `isCentered`, which triggers another render
- **Proposed Solution:** Stabilize `isCentered` calculation to prevent rapid recalculation, or decouple width-based classes from `isCentered` dependency

# Resources
- Component: `src/components/paragraph/sul-button.tsx`
- Hook: `src/lib/hooks/useIsCentered.tsx`
